### PR TITLE
Native PKCE OAuth login (drop npx mcp-remote)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,17 @@ tvly extract https://example.com
 ### 1. Authenticate
 
 ```bash
-# Set API key directly
+# Browser OAuth (no Node.js required)
+tvly login
+
+# Headless / SSH: print the URL instead of opening a browser
+tvly login --no-browser
+
+# Or set API key directly
 tvly login --api-key tvly-YOUR_KEY
 
 # Or use environment variable
 export TAVILY_API_KEY=tvly-YOUR_KEY
-
-# Or OAuth (opens browser)
-tvly login
 
 # Check auth status
 tvly auth

--- a/tavily_cli/cli.py
+++ b/tavily_cli/cli.py
@@ -53,11 +53,16 @@ def _print_welcome() -> None:
     from rich.console import Console
     from rich.text import Text
 
+    from tavily_cli.common import handle_oauth_refresh_error
     from tavily_cli.config import get_api_key
+    from tavily_cli.oauth import OAuthError
     from tavily_cli.theme import LOGO
 
     console = Console(stderr=True)
-    key = get_api_key()
+    try:
+        key = get_api_key()
+    except OAuthError as e:
+        handle_oauth_refresh_error(e, False)
 
     # Logo + version
     console.print()
@@ -70,9 +75,9 @@ def _print_welcome() -> None:
         source = _auth_source(key)
         console.print(f"  [#9BC0AE]>[/#9BC0AE] Authenticated via {source}")
     else:
-        console.print(f"  [#FAA2FB]>[/#FAA2FB] Not authenticated")
-        console.print(f"    [dim]search and extract work without a key (with a rate-limit cap).[/dim]")
-        console.print(f"    [dim]Run:[/dim] tvly login [dim]to remove the cap.[/dim]")
+        console.print("  [#FAA2FB]>[/#FAA2FB] Not authenticated")
+        console.print("    [dim]search and extract work without a key (with a rate-limit cap).[/dim]")
+        console.print("    [dim]Run:[/dim] tvly login [dim]to remove the cap.[/dim]")
 
     console.print()
 
@@ -104,6 +109,7 @@ def _print_welcome() -> None:
 def _auth_source(key: str) -> str:
     """Describe how the user is authenticated."""
     import os
+
     from tavily_cli.config import is_oauth_token
 
     if os.environ.get("TAVILY_API_KEY"):
@@ -117,9 +123,14 @@ def _print_status(json_output: bool) -> None:
     """Show version + auth status."""
     import json
 
+    from tavily_cli.common import handle_oauth_refresh_error
     from tavily_cli.config import get_api_key
+    from tavily_cli.oauth import OAuthError
 
-    key = get_api_key()
+    try:
+        key = get_api_key()
+    except OAuthError as e:
+        handle_oauth_refresh_error(e, json_output)
     authenticated = key is not None
 
     if json_output:

--- a/tavily_cli/cli.py
+++ b/tavily_cli/cli.py
@@ -8,6 +8,7 @@ from tavily_cli import __version__
 from tavily_cli.commands.auth import auth_status, login, logout
 from tavily_cli.commands.crawl import crawl
 from tavily_cli.commands.extract import extract
+from tavily_cli.commands.init import init_command
 from tavily_cli.commands.map_cmd import map_urls
 from tavily_cli.commands.research import research
 from tavily_cli.commands.search import search
@@ -142,6 +143,7 @@ def _print_status(json_output: bool) -> None:
 cli.add_command(login)
 cli.add_command(logout)
 cli.add_command(auth_status)
+cli.add_command(init_command)
 cli.add_command(search)
 cli.add_command(extract)
 cli.add_command(crawl)

--- a/tavily_cli/commands/auth.py
+++ b/tavily_cli/commands/auth.py
@@ -6,90 +6,88 @@ import click
 
 from tavily_cli.config import (
     CONFIG_FILE,
-    MCP_AUTH_DIR,
     clear_credentials,
     get_api_key,
     save_api_key,
+    save_oauth_session,
 )
-
-
-def _clear_stale_mcp_state() -> None:
-    """Remove stale mcp-remote client registrations so OAuth can re-register fresh."""
-    if not MCP_AUTH_DIR.is_dir():
-        return
-    for client_file in MCP_AUTH_DIR.rglob("*_client_info.json"):
-        try:
-            client_file.unlink()
-        except OSError:
-            pass
-    for token_file in MCP_AUTH_DIR.rglob("*_tokens.json"):
-        try:
-            token_file.unlink()
-        except OSError:
-            pass
 
 
 @click.command()
 @click.option("--api-key", default=None, help="Tavily API key (tvly-...). If omitted, opens browser for OAuth.")
-def login(api_key: str | None) -> None:
+@click.option(
+    "--no-browser",
+    is_flag=True,
+    default=False,
+    help="Print the login URL instead of opening a browser (SSH / headless).",
+)
+@click.option("--json", "json_flag", is_flag=True, default=False, help="Output as JSON.")
+@click.pass_context
+def login(ctx: click.Context, api_key: str | None, no_browser: bool, json_flag: bool) -> None:
     """Authenticate with Tavily. Stores credentials for future use."""
-    from tavily_cli.theme import console, err_console
+    from tavily_cli.theme import err_console
+
+    json_mode = json_flag
+    if not json_mode and ctx.parent and ctx.parent.obj:
+        json_mode = ctx.parent.obj.get("json_output", False)
 
     if api_key:
         save_api_key(api_key)
-        _print_login_success("API key", f"Saved to {CONFIG_FILE}")
+        _print_login_success("API key", f"Saved to {CONFIG_FILE}", json_mode=json_mode)
         return
 
-    # OAuth flow via mcp-remote
-    import subprocess
-    import time
+    from tavily_cli.oauth import OAuthError, looks_headless, run_browser_login
 
-    from tavily_cli.config import _get_mcp_token
+    open_browser = not (no_browser or looks_headless())
 
-    # Clear stale client registrations that cause "client ID not found" errors
-    _clear_stale_mcp_state()
-
-    token = None
-    with err_console.status("[#5CD9E6]Waiting for browser authentication...[/#5CD9E6]", spinner="dots") as live:
-        proc = subprocess.Popen(
-            ["npx", "-y", "mcp-remote", "https://mcp.tavily.com/mcp"],
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-
-        timeout = 120
-        elapsed = 0
-        try:
-            while elapsed < timeout:
-                time.sleep(3)
-                elapsed += 3
-                live.update(f"[#5CD9E6]Waiting for browser authentication... {elapsed}s[/#5CD9E6]")
-                token = _get_mcp_token()
-                if token:
-                    break
-        finally:
-            proc.terminate()
-            try:
-                proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-
-    if token:
-        _print_login_success("OAuth", "Token stored in ~/.mcp-auth/")
-    else:
+    def _show_url(url: str) -> None:
+        if json_mode:
+            return
         err_console.print()
-        err_console.print("  [#FAA2FB]> Authentication timed out.[/#FAA2FB]")
+        if open_browser:
+            err_console.print("  [#5CD9E6]>[/#5CD9E6] Opening the browser to sign in with Tavily.")
+            err_console.print("    [dim]If nothing opens, visit:[/dim]")
+        else:
+            err_console.print("  [#5CD9E6]>[/#5CD9E6] Open this URL in a browser on this machine:")
+        err_console.print(f"    {url}")
         err_console.print()
-        err_console.print("  If you don't have an account, sign up at [link=https://tavily.com]tavily.com[/link]")
-        err_console.print("  Or use an API key:")
-        err_console.print("    [#9BC0AE]tvly login --api-key tvly-YOUR_KEY[/#9BC0AE]")
-        err_console.print()
-        raise SystemExit(3)
+        if not open_browser:
+            err_console.print(
+                "    [dim]Headless / SSH sessions cannot complete browser login unless "
+                "this machine can receive http://127.0.0.1 callbacks.[/dim]"
+            )
+            err_console.print("    [dim]Use[/dim] [#9BC0AE]tvly login --api-key tvly-YOUR_KEY[/#9BC0AE] [dim]instead.[/dim]")
+            err_console.print()
+
+    try:
+        if json_mode:
+            session = run_browser_login(open_browser=open_browser, on_status=None)
+        else:
+            with err_console.status("[#5CD9E6]Waiting for browser authorization...[/#5CD9E6]", spinner="dots"):
+                session = run_browser_login(open_browser=open_browser, on_status=_show_url)
+    except OAuthError as e:
+        _print_login_failure(str(e), json_mode=json_mode)
+        raise SystemExit(3) from e
+    except KeyboardInterrupt:
+        _print_login_failure("Login cancelled.", json_mode=json_mode)
+        raise SystemExit(3) from None
+
+    save_oauth_session(session)
+    _print_login_success("OAuth", f"Token stored in {CONFIG_FILE}", json_mode=json_mode)
 
 
-def _print_login_success(method: str, detail: str) -> None:
+def _print_login_success(method: str, detail: str, *, json_mode: bool) -> None:
     """Print a branded success screen after login."""
+    if json_mode:
+        import json as json_mod
+
+        click.echo(json_mod.dumps({
+            "authenticated": True,
+            "method": "oauth" if method == "OAuth" else "api_key",
+            "detail": detail,
+        }))
+        return
+
     from rich.text import Text
 
     from tavily_cli.theme import LOGO, console
@@ -121,12 +119,48 @@ def _print_login_success(method: str, detail: str) -> None:
     console.print(hints)
 
 
-@click.command()
-def logout() -> None:
-    """Clear stored Tavily credentials."""
+def _print_login_failure(message: str, *, json_mode: bool) -> None:
+    if json_mode:
+        import json as json_mod
+
+        click.echo(json_mod.dumps({
+            "authenticated": False,
+            "error": message,
+        }))
+        return
+
+    from rich.markup import escape
+
+    from tavily_cli.common import sanitize_control
     from tavily_cli.theme import err_console
 
+    err_console.print()
+    err_console.print(f"  [#FAA2FB]> {escape(sanitize_control(message))}[/#FAA2FB]")
+    err_console.print()
+    err_console.print("  If you don't have an account, sign up at [link=https://tavily.com]tavily.com[/link]")
+    err_console.print("  Or use an API key:")
+    err_console.print("    [#9BC0AE]tvly login --api-key tvly-YOUR_KEY[/#9BC0AE]")
+    err_console.print()
+
+
+@click.command()
+@click.option("--json", "json_flag", is_flag=True, default=False, help="Output as JSON.")
+@click.pass_context
+def logout(ctx: click.Context, json_flag: bool) -> None:
+    """Clear stored Tavily credentials."""
+    json_mode = json_flag
+    if not json_mode and ctx.parent and ctx.parent.obj:
+        json_mode = ctx.parent.obj.get("json_output", False)
+
     clear_credentials()
+    if json_mode:
+        import json as json_mod
+
+        click.echo(json_mod.dumps({"authenticated": False}))
+        return
+
+    from tavily_cli.theme import err_console
+
     err_console.print("  [dim]Credentials cleared.[/dim]")
     err_console.print("  Run [#9BC0AE]tvly login[/#9BC0AE] to authenticate again.")
 
@@ -148,17 +182,28 @@ def auth_status(ctx: click.Context, json_flag: bool) -> None:
 
     key = get_api_key()
     source = None
+    method = None
     if key:
         if os.environ.get("TAVILY_API_KEY"):
             source = "TAVILY_API_KEY environment variable"
+            method = "env"
         elif is_oauth_token(key):
-            source = "OAuth (~/.mcp-auth/)"
+            from tavily_cli.config import has_stored_oauth
+
+            if has_stored_oauth():
+                source = f"OAuth ({CONFIG_FILE})"
+                method = "oauth"
+            else:
+                source = "OAuth (~/.mcp-auth/)"
+                method = "oauth_legacy"
         elif CONFIG_FILE.exists():
             source = f"config file ({CONFIG_FILE})"
+            method = "api_key"
 
     if json_mode:
         click.echo(json_mod.dumps({
             "authenticated": key is not None,
+            "method": method,
             "source": source,
         }))
     else:
@@ -168,7 +213,7 @@ def auth_status(ctx: click.Context, json_flag: bool) -> None:
             console.print(f"  [#9BC0AE]>[/#9BC0AE] Authenticated via {source}")
             console.print(f"    [dim]Key: {masked}[/dim]")
         else:
-            console.print(f"  [#FAA2FB]>[/#FAA2FB] Not authenticated")
+            console.print("  [#FAA2FB]>[/#FAA2FB] Not authenticated")
             console.print()
             console.print("  Run [#9BC0AE]tvly login[/#9BC0AE] to authenticate.")
         console.print()

--- a/tavily_cli/commands/auth.py
+++ b/tavily_cli/commands/auth.py
@@ -31,12 +31,16 @@ def login(ctx: click.Context, api_key: str | None, no_browser: bool, json_flag: 
     if not json_mode and ctx.parent and ctx.parent.obj:
         json_mode = ctx.parent.obj.get("json_output", False)
 
+    from tavily_cli.oauth import OAuthError, looks_headless, run_browser_login
+
     if api_key:
-        save_api_key(api_key)
+        try:
+            save_api_key(api_key)
+        except OAuthError as e:
+            _print_login_failure(str(e), json_mode=json_mode)
+            raise SystemExit(3) from e
         _print_login_success("API key", f"Saved to {CONFIG_FILE}", json_mode=json_mode)
         return
-
-    from tavily_cli.oauth import OAuthError, looks_headless, run_browser_login
 
     open_browser = not (no_browser or looks_headless())
 
@@ -74,6 +78,7 @@ def login(ctx: click.Context, api_key: str | None, no_browser: bool, json_flag: 
         else:
             with err_console.status("[#5CD9E6]Waiting for browser authorization...[/#5CD9E6]", spinner="dots"):
                 session = run_browser_login(open_browser=open_browser, on_status=_show_url)
+        save_oauth_session(session)
     except OAuthError as e:
         _print_login_failure(str(e), json_mode=json_mode)
         raise SystemExit(3) from e
@@ -81,7 +86,6 @@ def login(ctx: click.Context, api_key: str | None, no_browser: bool, json_flag: 
         _print_login_failure("Login cancelled.", json_mode=json_mode)
         raise SystemExit(3) from None
 
-    save_oauth_session(session)
     _print_login_success("OAuth", f"Token stored in {CONFIG_FILE}", json_mode=json_mode)
 
 

--- a/tavily_cli/commands/auth.py
+++ b/tavily_cli/commands/auth.py
@@ -42,6 +42,12 @@ def login(ctx: click.Context, api_key: str | None, no_browser: bool, json_flag: 
 
     def _show_url(url: str) -> None:
         if json_mode:
+            import json as json_mod
+
+            click.echo(json_mod.dumps({
+                "event": "authorization_required",
+                "authorization_url": url,
+            }), err=True)
             return
         err_console.print()
         if open_browser:
@@ -61,7 +67,10 @@ def login(ctx: click.Context, api_key: str | None, no_browser: bool, json_flag: 
 
     try:
         if json_mode:
-            session = run_browser_login(open_browser=open_browser, on_status=None)
+            session = run_browser_login(
+                open_browser=open_browser,
+                on_status=_show_url if not open_browser else None,
+            )
         else:
             with err_console.status("[#5CD9E6]Waiting for browser authorization...[/#5CD9E6]", spinner="dots"):
                 session = run_browser_login(open_browser=open_browser, on_status=_show_url)

--- a/tavily_cli/commands/auth.py
+++ b/tavily_cli/commands/auth.py
@@ -152,16 +152,47 @@ def logout(ctx: click.Context, json_flag: bool) -> None:
     if not json_mode and ctx.parent and ctx.parent.obj:
         json_mode = ctx.parent.obj.get("json_output", False)
 
-    clear_credentials()
+    result = clear_credentials()
+    if result.revocation_error:
+        if json_mode:
+            import json as json_mod
+
+            click.echo(json_mod.dumps({
+                "authenticated": False,
+                "local_credentials_cleared": result.local_credentials_cleared,
+                "server_revoked": False,
+                "error": result.revocation_error,
+            }))
+        else:
+            from rich.markup import escape
+
+            from tavily_cli.common import sanitize_control
+            from tavily_cli.theme import err_console
+
+            detail = escape(sanitize_control(result.revocation_error))
+            err_console.print("  [#FFC769]>[/#FFC769] Local credentials cleared, but server revocation failed.")
+            err_console.print(f"    [dim]{detail}[/dim]")
+            err_console.print("  The previous OAuth token may remain usable; run [#9BC0AE]tvly login[/#9BC0AE] again if needed.")
+        raise SystemExit(3)
+
     if json_mode:
         import json as json_mod
 
-        click.echo(json_mod.dumps({"authenticated": False}))
+        payload = {
+            "authenticated": False,
+            "local_credentials_cleared": result.local_credentials_cleared,
+        }
+        if result.server_revoked is not None:
+            payload["server_revoked"] = result.server_revoked
+        click.echo(json_mod.dumps(payload))
         return
 
     from tavily_cli.theme import err_console
 
-    err_console.print("  [dim]Credentials cleared.[/dim]")
+    if result.server_revoked:
+        err_console.print("  [dim]Server session revoked and credentials cleared.[/dim]")
+    else:
+        err_console.print("  [dim]Credentials cleared.[/dim]")
     err_console.print("  Run [#9BC0AE]tvly login[/#9BC0AE] to authenticate again.")
 
 

--- a/tavily_cli/commands/auth.py
+++ b/tavily_cli/commands/auth.py
@@ -12,6 +12,11 @@ from tavily_cli.config import (
     save_oauth_session,
 )
 
+_ENV_CREDENTIAL_WARNING = (
+    "TAVILY_API_KEY is still set and cannot be removed from the parent environment by this process. "
+    "Run: unset TAVILY_API_KEY"
+)
+
 
 @click.command()
 @click.option("--api-key", default=None, help="Tavily API key (tvly-...). If omitted, opens browser for OAuth.")
@@ -156,6 +161,32 @@ def _print_login_failure(message: str, *, json_mode: bool) -> None:
     err_console.print()
 
 
+def _effective_auth_state() -> tuple[str | None, str | None, str | None]:
+    """Return the effective credential and its method/source."""
+    import os
+
+    from tavily_cli.config import has_stored_oauth, is_oauth_token
+
+    key = get_api_key()
+    source = None
+    method = None
+    if key:
+        if os.environ.get("TAVILY_API_KEY"):
+            source = "TAVILY_API_KEY environment variable"
+            method = "env"
+        elif is_oauth_token(key):
+            if has_stored_oauth():
+                source = f"OAuth ({CONFIG_FILE})"
+                method = "oauth"
+            else:
+                source = "OAuth (~/.mcp-auth/)"
+                method = "oauth_legacy"
+        elif CONFIG_FILE.exists():
+            source = f"config file ({CONFIG_FILE})"
+            method = "api_key"
+    return key, method, source
+
+
 @click.command()
 @click.option("--json", "json_flag", is_flag=True, default=False, help="Output as JSON.")
 @click.pass_context
@@ -166,16 +197,25 @@ def logout(ctx: click.Context, json_flag: bool) -> None:
         json_mode = ctx.parent.obj.get("json_output", False)
 
     result = clear_credentials()
+    key, method, source = _effective_auth_state()
+    environment_credential_present = method == "env"
+    payload = {
+        "authenticated": key is not None,
+        "method": method,
+        "source": source,
+        "local_credentials_cleared": result.local_credentials_cleared,
+        "environment_credential_present": environment_credential_present,
+    }
+    if environment_credential_present:
+        payload["warning"] = _ENV_CREDENTIAL_WARNING
+
     if result.revocation_error:
         if json_mode:
             import json as json_mod
 
-            click.echo(json_mod.dumps({
-                "authenticated": False,
-                "local_credentials_cleared": result.local_credentials_cleared,
-                "server_revoked": False,
-                "error": result.revocation_error,
-            }))
+            payload["server_revoked"] = False
+            payload["error"] = result.revocation_error
+            click.echo(json_mod.dumps(payload))
         else:
             from rich.markup import escape
 
@@ -185,16 +225,15 @@ def logout(ctx: click.Context, json_flag: bool) -> None:
             detail = escape(sanitize_control(result.revocation_error))
             err_console.print("  [#FFC769]>[/#FFC769] Local credentials cleared, but server revocation failed.")
             err_console.print(f"    [dim]{detail}[/dim]")
-            err_console.print("  The previous OAuth token may remain usable; run [#9BC0AE]tvly login[/#9BC0AE] again if needed.")
+            err_console.print("  The previous OAuth token may remain usable.")
+            if environment_credential_present:
+                err_console.print("  [#FFC769]>[/#FFC769] TAVILY_API_KEY is still set, so the CLI remains authenticated.")
+                err_console.print("    [dim]Run in your shell: unset TAVILY_API_KEY[/dim]")
         raise SystemExit(3)
 
     if json_mode:
         import json as json_mod
 
-        payload = {
-            "authenticated": False,
-            "local_credentials_cleared": result.local_credentials_cleared,
-        }
         if result.server_revoked is not None:
             payload["server_revoked"] = result.server_revoked
         click.echo(json_mod.dumps(payload))
@@ -206,7 +245,11 @@ def logout(ctx: click.Context, json_flag: bool) -> None:
         err_console.print("  [dim]Server session revoked and credentials cleared.[/dim]")
     else:
         err_console.print("  [dim]Credentials cleared.[/dim]")
-    err_console.print("  Run [#9BC0AE]tvly login[/#9BC0AE] to authenticate again.")
+    if environment_credential_present:
+        err_console.print("  [#FFC769]>[/#FFC769] TAVILY_API_KEY is still set, so the CLI remains authenticated.")
+        err_console.print("    [dim]Run in your shell: unset TAVILY_API_KEY[/dim]")
+    else:
+        err_console.print("  Run [#9BC0AE]tvly login[/#9BC0AE] to authenticate again.")
 
 
 @click.command("auth")
@@ -215,34 +258,14 @@ def logout(ctx: click.Context, json_flag: bool) -> None:
 def auth_status(ctx: click.Context, json_flag: bool) -> None:
     """Check authentication status."""
     import json as json_mod
-    import os
 
-    from tavily_cli.config import is_oauth_token
     from tavily_cli.theme import console
 
     json_mode = json_flag
     if not json_mode and ctx.parent and ctx.parent.obj:
         json_mode = ctx.parent.obj.get("json_output", False)
 
-    key = get_api_key()
-    source = None
-    method = None
-    if key:
-        if os.environ.get("TAVILY_API_KEY"):
-            source = "TAVILY_API_KEY environment variable"
-            method = "env"
-        elif is_oauth_token(key):
-            from tavily_cli.config import has_stored_oauth
-
-            if has_stored_oauth():
-                source = f"OAuth ({CONFIG_FILE})"
-                method = "oauth"
-            else:
-                source = "OAuth (~/.mcp-auth/)"
-                method = "oauth_legacy"
-        elif CONFIG_FILE.exists():
-            source = f"config file ({CONFIG_FILE})"
-            method = "api_key"
+    key, method, source = _effective_auth_state()
 
     if json_mode:
         click.echo(json_mod.dumps({

--- a/tavily_cli/commands/auth.py
+++ b/tavily_cli/commands/auth.py
@@ -155,8 +155,7 @@ def _print_login_failure(message: str, *, json_mode: bool) -> None:
     err_console.print()
     err_console.print(f"  [#FAA2FB]> {escape(sanitize_control(message))}[/#FAA2FB]")
     err_console.print()
-    err_console.print("  If you don't have an account, sign up at [link=https://tavily.com]tavily.com[/link]")
-    err_console.print("  Or use an API key:")
+    err_console.print("  Use an API key instead:")
     err_console.print("    [#9BC0AE]tvly login --api-key tvly-YOUR_KEY[/#9BC0AE]")
     err_console.print()
 
@@ -265,7 +264,14 @@ def auth_status(ctx: click.Context, json_flag: bool) -> None:
     if not json_mode and ctx.parent and ctx.parent.obj:
         json_mode = ctx.parent.obj.get("json_output", False)
 
-    key, method, source = _effective_auth_state()
+    from tavily_cli.oauth import OAuthError
+
+    try:
+        key, method, source = _effective_auth_state()
+    except OAuthError as e:
+        from tavily_cli.common import handle_oauth_refresh_error
+
+        handle_oauth_refresh_error(e, json_mode)
 
     if json_mode:
         click.echo(json_mod.dumps({

--- a/tavily_cli/commands/crawl.py
+++ b/tavily_cli/commands/crawl.py
@@ -57,8 +57,8 @@ def crawl(
     from tavily_cli.config import get_client, require_api_key_friendly
     from tavily_cli.output import print_crawl_results
 
-    require_api_key_friendly("crawl")
-    client = get_client(client_name=client_name)
+    require_api_key_friendly("crawl", json_mode=json_output)
+    client = get_client(client_name=client_name, json_mode=json_output)
 
     kwargs: dict = {"url": url}
     if max_depth is not None:

--- a/tavily_cli/commands/extract.py
+++ b/tavily_cli/commands/extract.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import click
-
 from tavily import TavilyKeylessLimitError
 
-from tavily_cli.common import client_name_option, handle_api_error, handle_keyless_cap_hit, json_option
+from tavily_cli.common import (
+    client_name_option,
+    handle_api_error,
+    handle_keyless_cap_hit,
+    handle_oauth_refresh_error,
+    json_option,
+)
 
 
 @click.command()
@@ -42,8 +47,6 @@ def extract(
     from tavily_cli.config import get_client_or_keyless
     from tavily_cli.output import print_extract_results
 
-    client, _is_keyless = get_client_or_keyless(client_name=client_name)
-
     url_list = list(urls)
     if len(url_list) > 20:
         raise click.UsageError("Maximum 20 URLs per request.")
@@ -62,13 +65,17 @@ def extract(
     if timeout is not None:
         kwargs["timeout"] = timeout
 
+    from tavily_cli.oauth import OAuthError
     from tavily_cli.theme import spinner
 
     try:
+        client, _is_keyless = get_client_or_keyless(client_name=client_name)
         with spinner(f"Extracting {len(url_list)} URL{'s' if len(url_list) > 1 else ''}...", json_mode=json_output):
             response = client.extract(**kwargs)
     except TavilyKeylessLimitError as e:
         handle_keyless_cap_hit(e, json_output)
+    except OAuthError as e:
+        handle_oauth_refresh_error(e, json_output)
     except Exception as e:
         handle_api_error(e, json_output)
 

--- a/tavily_cli/commands/init.py
+++ b/tavily_cli/commands/init.py
@@ -1,0 +1,263 @@
+"""One-shot Tavily CLI and agent skill setup."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+from typing import Any
+
+import click
+
+from tavily_cli import __version__
+from tavily_cli.common import json_option
+from tavily_cli.init_skills import (
+    SKILLS_SOURCE,
+    agent_specs,
+    detect_agents,
+    install_skills,
+    verify_skills,
+)
+
+_AGENT_CHOICES = tuple(agent_specs())
+
+
+@click.command("init")
+@click.option(
+    "--agent",
+    "agents",
+    type=click.Choice(_AGENT_CHOICES, case_sensitive=False),
+    multiple=True,
+    help="Install skills for an agent. Repeat to select more than one.",
+)
+@click.option("--all", "all_agents", is_flag=True, help="Install skills for every detected agent.")
+@click.option("--yes", "assume_yes", is_flag=True, help="Accept detected agents without prompting.")
+@click.option("--skip-auth", is_flag=True, help="Keep keyless mode when no credential is configured.")
+@click.option("--skip-skills", is_flag=True, help="Do not install or update Tavily agent skills.")
+@click.option("--api-key", default=None, help="Authenticate with a Tavily API key instead of OAuth.")
+@click.option(
+    "--browser/--no-browser",
+    default=None,
+    help="Open OAuth in a browser, or print the URL and wait for its local callback.",
+)
+@json_option
+def init_command(
+    agents: tuple[str, ...],
+    all_agents: bool,
+    assume_yes: bool,
+    skip_auth: bool,
+    skip_skills: bool,
+    api_key: str | None,
+    browser: bool | None,
+    json_output: bool,
+) -> None:
+    """Authenticate, install Tavily skills, and verify a working CLI."""
+    if all_agents and agents:
+        raise click.UsageError("Use either --all or --agent, not both.")
+    if skip_auth and api_key:
+        raise click.UsageError("Use either --skip-auth or --api-key, not both.")
+
+    selected_agents = _select_agents(agents, all_agents, assume_yes, skip_skills, json_output)
+    result = _empty_result(selected_agents)
+    result["skills"]["skipped"] = skip_skills
+
+    try:
+        auth = _ensure_auth(api_key=api_key, skip_auth=skip_auth, browser=browser, json_output=json_output)
+    except Exception as exc:
+        _fail(result, "auth", str(exc), 3, json_output)
+        return
+    result["auth"] = auth
+    result["mode"] = "authenticated" if auth["authenticated"] else "keyless"
+    result["verification"]["auth"] = auth["authenticated"]
+
+    if not skip_skills:
+        try:
+            skills_result = install_skills(selected_agents)
+            result["skills"].update({
+                "installed": skills_result.installed,
+                "updated": skills_result.updated,
+                "unchanged": skills_result.unchanged,
+                "total": skills_result.total,
+                "linked": skills_result.linked,
+                "restart_required": skills_result.restart_required,
+            })
+            result["verification"]["skills"] = verify_skills(selected_agents)
+            if not result["verification"]["skills"]:
+                raise RuntimeError("Installed Tavily skills could not be verified.")
+        except Exception as exc:
+            _fail(result, "skills", str(exc), 1, json_output)
+            return
+
+    result["verification"]["cli"] = _verify_cli()
+    if not result["verification"]["cli"]:
+        _fail(result, "cli", "tvly is not available on PATH.", 1, json_output)
+        return
+
+    try:
+        result["verification"]["live_search"] = _verify_live_search()
+    except Exception as exc:
+        _fail(result, "live_search", str(exc), 4, json_output)
+        return
+    if not result["verification"]["live_search"]:
+        _fail(result, "live_search", "Tavily search returned no result payload.", 4, json_output)
+        return
+
+    result["ok"] = True
+    _print_result(result, json_output=json_output)
+
+
+def _select_agents(
+    requested: tuple[str, ...],
+    all_agents: bool,
+    assume_yes: bool,
+    skip_skills: bool,
+    json_output: bool,
+) -> tuple[str, ...]:
+    if skip_skills:
+        return ()
+    if requested:
+        return tuple(dict.fromkeys(name.lower() for name in requested))
+
+    detected = detect_agents()
+    if not detected or all_agents or assume_yes or json_output or not sys.stdin.isatty():
+        return detected
+
+    label = ", ".join(detected)
+    if click.confirm(f"Install Tavily skills for detected agents ({label})?", default=True):
+        return detected
+    return ()
+
+
+def _ensure_auth(
+    *,
+    api_key: str | None,
+    skip_auth: bool,
+    browser: bool | None,
+    json_output: bool,
+) -> dict[str, Any]:
+    from tavily_cli.config import get_api_key, save_api_key, save_oauth_session
+
+    if api_key:
+        save_api_key(api_key)
+    key = get_api_key()
+    if key:
+        return {"authenticated": True, "method": _auth_method(key)}
+    if skip_auth:
+        return {"authenticated": False, "method": "none"}
+
+    if browser is None and not sys.stdin.isatty():
+        raise RuntimeError(
+            "No Tavily credential found. Use --api-key, --browser, --no-browser, or --skip-auth in non-interactive runs."
+        )
+
+    from tavily_cli.oauth import looks_headless, run_browser_login
+
+    open_browser = browser if browser is not None else not looks_headless()
+
+    def show_url(url: str) -> None:
+        click.echo(f"Open this URL to authenticate: {url}", err=True)
+
+    session = run_browser_login(open_browser=open_browser, on_status=show_url)
+    save_oauth_session(session)
+    return {"authenticated": True, "method": "oauth"}
+
+
+def _auth_method(key: str) -> str:
+    from tavily_cli.config import has_stored_oauth, is_oauth_token
+
+    if os.environ.get("TAVILY_API_KEY"):
+        return "env"
+    if is_oauth_token(key):
+        return "oauth" if has_stored_oauth() else "oauth_legacy"
+    return "api_key"
+
+
+def _verify_cli() -> bool:
+    return shutil.which("tvly") is not None
+
+
+def _verify_live_search() -> bool:
+    from tavily_cli.config import get_client_or_keyless
+
+    client, _ = get_client_or_keyless(client_name="tavily-cli-init")
+    response = client.search(query="Tavily Search API", max_results=1)
+    return isinstance(response, dict) and isinstance(response.get("results"), list)
+
+
+def _empty_result(agents: tuple[str, ...]) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "version": __version__,
+        "mode": "unknown",
+        "auth": {"authenticated": False, "method": "none"},
+        "skills": {
+            "source": SKILLS_SOURCE,
+            "agents": list(agents),
+            "installed": 0,
+            "updated": 0,
+            "unchanged": 0,
+            "total": 0,
+            "linked": 0,
+            "restart_required": False,
+            "skipped": False,
+        },
+        "verification": {
+            "cli": False,
+            "auth": False,
+            "skills": None,
+            "live_search": False,
+        },
+    }
+
+
+def _fail(result: dict[str, Any], stage: str, message: str, exit_code: int, json_output: bool) -> None:
+    result["error"] = {"stage": stage, "message": message}
+    _print_result(result, json_output=json_output)
+    raise click.exceptions.Exit(exit_code)
+
+
+def _print_result(result: dict[str, Any], *, json_output: bool) -> None:
+    if json_output:
+        click.echo(json.dumps(result, sort_keys=True))
+        return
+
+    from rich.markup import escape
+
+    from tavily_cli.common import sanitize_control
+    from tavily_cli.theme import console
+
+    console.print()
+    if result["ok"]:
+        console.print("  [bold #9BC0AE]> Tavily is ready[/bold #9BC0AE]")
+    else:
+        error = result.get("error", {})
+        message = escape(sanitize_control(error.get("message", "Initialization failed.")))
+        console.print(f"  [bold #FAA2FB]> Setup failed:[/bold #FAA2FB] {message}")
+        console.print()
+        return
+
+    auth = result["auth"]
+    if auth["authenticated"]:
+        console.print(f"    [#9BC0AE]✓[/#9BC0AE] Authenticated via {auth['method']}")
+    else:
+        console.print("    [#FFC769]•[/#FFC769] Keyless mode")
+
+    skills = result["skills"]
+    if skills["skipped"]:
+        console.print("    [dim]• Skills skipped[/dim]")
+    else:
+        agents = ", ".join(skills["agents"]) or "shared agent directory"
+        console.print(f"    [#9BC0AE]✓[/#9BC0AE] {skills['total']} Tavily skills ready for {agents}")
+    console.print("    [#9BC0AE]✓[/#9BC0AE] Live search verified")
+
+    if skills["restart_required"] and skills["agents"]:
+        console.print()
+        console.print(f"    [dim]Restart {', '.join(skills['agents'])} to load newly installed skills.[/dim]")
+
+    console.print()
+    console.print("  Try:")
+    console.print('    [#9BC0AE]tvly search "latest AI news"[/#9BC0AE]')
+    console.print("    [#9BC0AE]tvly extract https://example.com[/#9BC0AE]")
+    console.print("    [#9BC0AE]tvly research \"your topic\"[/#9BC0AE]")
+    console.print()

--- a/tavily_cli/commands/map_cmd.py
+++ b/tavily_cli/commands/map_cmd.py
@@ -47,8 +47,8 @@ def map_urls(
     from tavily_cli.config import get_client, require_api_key_friendly
     from tavily_cli.output import print_map_results
 
-    require_api_key_friendly("map")
-    client = get_client(client_name=client_name)
+    require_api_key_friendly("map", json_mode=json_output)
+    client = get_client(client_name=client_name, json_mode=json_output)
 
     kwargs: dict = {"url": url}
     if max_depth is not None:

--- a/tavily_cli/commands/research.py
+++ b/tavily_cli/commands/research.py
@@ -9,7 +9,7 @@ import time
 import click
 from rich.markup import escape
 
-from tavily_cli.common import client_name_option, handle_api_error, json_option, sanitize_control
+from tavily_cli.common import client_name_option, handle_api_error, sanitize_control
 
 
 class ResearchGroup(click.Group):
@@ -164,8 +164,8 @@ def run(
     if not query:
         raise click.UsageError("QUERY is required. Pass a query string or use '-' to read from stdin.")
 
-    require_api_key_friendly("research")
-    client = get_client(client_name=client_name)
+    require_api_key_friendly("research", json_mode=json_mode)
+    client = get_client(client_name=client_name, json_mode=json_mode)
 
     schema = None
     if output_schema:
@@ -282,8 +282,8 @@ def status(ctx: click.Context, request_id: str, json_flag: bool, client_name: st
     from tavily_cli.output import emit
 
     json_mode = _resolve_json(ctx, json_flag)
-    require_api_key_friendly("research status")
-    client = get_client(client_name=client_name)
+    require_api_key_friendly("research status", json_mode=json_mode)
+    client = get_client(client_name=client_name, json_mode=json_mode)
 
     try:
         response = client.get_research(request_id)
@@ -328,8 +328,8 @@ def poll(
     from tavily_cli.theme import err_console
 
     json_mode = _resolve_json(ctx, json_flag)
-    require_api_key_friendly("research poll")
-    client = get_client(client_name=client_name)
+    require_api_key_friendly("research poll", json_mode=json_mode)
+    client = get_client(client_name=client_name, json_mode=json_mode)
 
     elapsed = 0
     response = {}

--- a/tavily_cli/commands/search.py
+++ b/tavily_cli/commands/search.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 import sys
 
 import click
-
 from tavily import TavilyKeylessLimitError
 
-from tavily_cli.common import client_name_option, handle_api_error, handle_keyless_cap_hit, json_option
+from tavily_cli.common import (
+    client_name_option,
+    handle_api_error,
+    handle_keyless_cap_hit,
+    handle_oauth_refresh_error,
+    json_option,
+)
 
 
 @click.command()
@@ -65,8 +70,6 @@ def search(
     if not query:
         raise click.UsageError("QUERY is required. Pass a query string or use '-' to read from stdin.")
 
-    client, _is_keyless = get_client_or_keyless(client_name=client_name)
-
     kwargs: dict = {"query": query}
     if search_depth is not None:
         kwargs["search_depth"] = search_depth
@@ -97,13 +100,17 @@ def search(
     if chunks_per_source is not None:
         kwargs["chunks_per_source"] = chunks_per_source
 
+    from tavily_cli.oauth import OAuthError
     from tavily_cli.theme import spinner
 
     try:
+        client, _is_keyless = get_client_or_keyless(client_name=client_name)
         with spinner("Searching...", json_mode=json_output):
             response = client.search(**kwargs)
     except TavilyKeylessLimitError as e:
         handle_keyless_cap_hit(e, json_output)
+    except OAuthError as e:
+        handle_oauth_refresh_error(e, json_output)
     except Exception as e:
         handle_api_error(e, json_output)
 

--- a/tavily_cli/common.py
+++ b/tavily_cli/common.py
@@ -2,16 +2,14 @@
 
 from __future__ import annotations
 
-import json
 import functools
+import json
 import re
 
 import click
-
 from tavily import TavilyKeylessLimitError
 
 from tavily_cli.keyless import format_keyless_envelope_for_terminal
-
 
 # C0/C1 control and escape bytes, minus tab (\x09), newline (\x0a), and
 # carriage return (\x0d). Stripping these from server- and web-derived text
@@ -76,6 +74,26 @@ def handle_keyless_cap_hit(e: TavilyKeylessLimitError, json_mode: bool) -> None:
         "and remove this cap.[/dim]"
     )
     err_console.print()
+    raise SystemExit(3)
+
+
+def handle_oauth_refresh_error(e: Exception, json_mode: bool) -> None:
+    """Render a stored OAuth refresh failure without treating it as logout."""
+    message = sanitize_control(e)
+    if json_mode:
+        click.echo(json.dumps({
+            "error": {
+                "code": "oauth_refresh_failed",
+                "message": message,
+            }
+        }))
+        raise SystemExit(3)
+
+    from rich.markup import escape
+
+    from tavily_cli.theme import err_console
+
+    err_console.print(f"  [#FAA2FB]> OAuth refresh failed:[/#FAA2FB] {escape(message)}")
     raise SystemExit(3)
 
 

--- a/tavily_cli/config.py
+++ b/tavily_cli/config.py
@@ -102,7 +102,35 @@ def _write_config(data: dict) -> None:
 def save_api_key(api_key: str) -> None:
     config = _read_config()
     config["api_key"] = api_key
+    config.pop("oauth", None)
     _write_config(config)
+
+
+def save_oauth_session(session) -> None:
+    """Persist OAuth tokens and the dynamically registered client in config.json."""
+    from tavily_cli.oauth import OAuthSession
+
+    if not isinstance(session, OAuthSession):
+        raise TypeError("session must be an OAuthSession")
+    config = _read_config()
+    config.pop("api_key", None)
+    config["oauth"] = {
+        "access_token": session.tokens.access_token,
+        "refresh_token": session.tokens.refresh_token,
+        "expires_at": session.tokens.expires_at,
+        "token_type": session.tokens.token_type,
+        "client_id": session.client.client_id,
+        "client_secret": session.client.client_secret,
+        "token_endpoint_auth_method": session.client.token_endpoint_auth_method,
+        "redirect_uri": session.client.redirect_uri,
+    }
+    _write_config(config)
+
+
+def has_stored_oauth() -> bool:
+    """True when ~/.tavily/config.json holds a native OAuth session."""
+    data = _read_config().get("oauth")
+    return isinstance(data, dict) and isinstance(data.get("access_token"), str)
 
 
 def get_human_id() -> str | None:
@@ -126,8 +154,17 @@ def get_api_base_url() -> str | None:
 
 
 def clear_credentials() -> None:
+    oauth = _read_config().get("oauth")
+    if isinstance(oauth, dict):
+        _revoke_stored_oauth(oauth)
     if CONFIG_FILE.exists():
-        CONFIG_FILE.unlink()
+        config = _read_config()
+        config.pop("api_key", None)
+        config.pop("oauth", None)
+        if config:
+            _write_config(config)
+        else:
+            CONFIG_FILE.unlink()
     _clear_mcp_tokens()
 
 
@@ -205,8 +242,69 @@ def _clear_mcp_tokens() -> None:
                 pass
 
 
+def _oauth_client_from_dict(data: dict):
+    from tavily_cli.oauth import RegisteredClient
+
+    client_id = data.get("client_id")
+    if not isinstance(client_id, str) or not client_id:
+        return None
+    return RegisteredClient(
+        client_id=client_id,
+        client_secret=data.get("client_secret") if isinstance(data.get("client_secret"), str) else None,
+        token_endpoint_auth_method=data.get("token_endpoint_auth_method") or "none",
+        redirect_uri=data.get("redirect_uri") or "http://127.0.0.1/callback",
+    )
+
+
+def _revoke_stored_oauth(data: dict) -> None:
+    """Best-effort token revocation. Never raises — logout must still clear disk."""
+    from tavily_cli.oauth import fetch_metadata, revoke_token
+
+    client = _oauth_client_from_dict(data)
+    if client is None:
+        return
+    try:
+        metadata = fetch_metadata()
+        for key in ("access_token", "refresh_token"):
+            token = data.get(key)
+            if isinstance(token, str) and token:
+                revoke_token(metadata, client, token)
+    except Exception:
+        return
+
+
+def _get_oauth_access_token(config: dict) -> str | None:
+    """Return a usable OAuth access token from config, refreshing if needed."""
+    from tavily_cli.oauth import (
+        OAuthSession,
+        fetch_metadata,
+        refresh_tokens,
+        token_is_expired,
+    )
+
+    data = config.get("oauth")
+    if not isinstance(data, dict):
+        return None
+    access = data.get("access_token")
+    if not isinstance(access, str) or not access:
+        return None
+    if not token_is_expired(data.get("expires_at")):
+        return access
+
+    refresh = data.get("refresh_token")
+    client = _oauth_client_from_dict(data)
+    if not isinstance(refresh, str) or not refresh or client is None:
+        return None
+    try:
+        tokens = refresh_tokens(fetch_metadata(), client, refresh)
+        save_oauth_session(OAuthSession(tokens=tokens, client=client))
+        return tokens.access_token
+    except Exception:
+        return None
+
+
 def get_api_key() -> str | None:
-    """Resolve the API key with precedence: env var > config file > MCP OAuth token."""
+    """Resolve credentials: env var > API key in config > OAuth in config > legacy ~/.mcp-auth."""
     key = os.environ.get("TAVILY_API_KEY")
     if key:
         return key
@@ -215,6 +313,10 @@ def get_api_key() -> str | None:
     key = config.get("api_key")
     if key:
         return key
+
+    token = _get_oauth_access_token(config)
+    if token:
+        return token
 
     return _get_mcp_token()
 
@@ -306,7 +408,7 @@ def require_api_key_friendly(command_name: str) -> str:
     )
     console.print()
     console.print("  Sign up for a free key at [link=https://tavily.com]https://tavily.com[/link]")
-    console.print("  Then run [#9BC0AE]tvly login --api-key tvly-YOUR_KEY[/#9BC0AE]")
+    console.print("  Then run [#9BC0AE]tvly login[/#9BC0AE] or [#9BC0AE]tvly login --api-key tvly-YOUR_KEY[/#9BC0AE]")
     console.print()
     console.print(
         "  [dim]Tip: [#9BC0AE]tvly search[/#9BC0AE] and [#9BC0AE]tvly extract[/#9BC0AE] "

--- a/tavily_cli/config.py
+++ b/tavily_cli/config.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
+from typing import BinaryIO
 from uuid import uuid4
 
 import psutil
@@ -15,6 +20,9 @@ CONFIG_FILE = CONFIG_DIR / "config.json"
 _SESSION_FILE = CONFIG_DIR / "session.json"
 
 MCP_AUTH_DIR = Path.home() / ".mcp-auth"
+
+_CONFIG_THREAD_LOCK = threading.RLock()
+_CONFIG_LOCK_STATE = threading.local()
 
 
 @dataclass(frozen=True)
@@ -98,15 +106,90 @@ def _read_config() -> dict:
     return {}
 
 
-def _write_config(data: dict) -> None:
-    old_umask = os.umask(0o077)  # ensure new files are owner-only from creation, sets the new umask to 0o077 and returns whatever the previous umask was.
-    try:
-        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+def _lock_file(lock_file: BinaryIO) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        lock_file.seek(0, os.SEEK_END)
+        if lock_file.tell() == 0:
+            lock_file.write(b"\0")
+            lock_file.flush()
+        lock_file.seek(0)
+        msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+        return
+
+    import fcntl
+
+    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+
+
+def _unlock_file(lock_file: BinaryIO) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        lock_file.seek(0)
+        msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+        return
+
+    import fcntl
+
+    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def _config_lock() -> Iterator[None]:
+    """Serialize config transactions across threads and CLI processes."""
+    with _CONFIG_THREAD_LOCK:
+        depth = getattr(_CONFIG_LOCK_STATE, "depth", 0)
+        if depth:
+            _CONFIG_LOCK_STATE.depth = depth + 1
+            try:
+                yield
+            finally:
+                _CONFIG_LOCK_STATE.depth -= 1
+            return
+
+        CONFIG_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
         CONFIG_DIR.chmod(0o700)
-        CONFIG_FILE.write_text(json.dumps(data, indent=2) + "\n")
+        lock_path = CONFIG_FILE.with_name(f".{CONFIG_FILE.name}.lock")
+        lock_fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+        with os.fdopen(lock_fd, "r+b", buffering=0) as lock_file:
+            lock_path.chmod(0o600)
+            _lock_file(lock_file)
+            _CONFIG_LOCK_STATE.depth = 1
+            try:
+                yield
+            finally:
+                _CONFIG_LOCK_STATE.depth = 0
+                _unlock_file(lock_file)
+
+
+def _write_config_unlocked(data: dict) -> None:
+    """Atomically replace config.json while the caller holds _config_lock."""
+    CONFIG_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    CONFIG_DIR.chmod(0o700)
+    payload = json.dumps(data, indent=2) + "\n"
+    descriptor, temp_name = tempfile.mkstemp(
+        dir=CONFIG_DIR,
+        prefix=f".{CONFIG_FILE.name}.",
+        suffix=".tmp",
+    )
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as temp_file:
+            temp_file.write(payload)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        temp_path.chmod(0o600)
+        os.replace(temp_path, CONFIG_FILE)
         CONFIG_FILE.chmod(0o600)
     finally:
-        os.umask(old_umask)
+        temp_path.unlink(missing_ok=True)
+
+
+def _write_config(data: dict) -> None:
+    with _config_lock():
+        _write_config_unlocked(data)
 
 
 def _oauth_session_data(session) -> dict:
@@ -129,13 +212,14 @@ def _oauth_session_data(session) -> dict:
 
 def save_api_key(api_key: str) -> None:
     """Replace stored credentials with an API key, revoking old OAuth first."""
-    config = _read_config()
-    previous_oauth = config.get("oauth")
-    if isinstance(previous_oauth, dict):
-        _revoke_stored_oauth(previous_oauth)
-    config["api_key"] = api_key
-    config.pop("oauth", None)
-    _write_config(config)
+    with _config_lock():
+        config = _read_config()
+        previous_oauth = config.get("oauth")
+        if isinstance(previous_oauth, dict):
+            _revoke_stored_oauth(previous_oauth)
+        config["api_key"] = api_key
+        config.pop("oauth", None)
+        _write_config_unlocked(config)
 
 
 def save_oauth_session(session) -> None:
@@ -143,32 +227,34 @@ def save_oauth_session(session) -> None:
     from tavily_cli.oauth import OAuthError
 
     replacement_oauth = _oauth_session_data(session)
-    config = _read_config()
-    previous_oauth = config.get("oauth")
-    if isinstance(previous_oauth, dict) and previous_oauth != replacement_oauth:
-        try:
-            _revoke_stored_oauth(previous_oauth)
-        except OAuthError as previous_error:
+    with _config_lock():
+        config = _read_config()
+        previous_oauth = config.get("oauth")
+        if isinstance(previous_oauth, dict) and previous_oauth != replacement_oauth:
             try:
-                _revoke_stored_oauth(replacement_oauth)
-            except OAuthError as cleanup_error:
-                raise OAuthError(
-                    f"Could not replace the previous OAuth session: {previous_error} "
-                    f"The new OAuth session also could not be revoked: {cleanup_error}"
-                ) from previous_error
-            raise OAuthError(f"Could not replace the previous OAuth session: {previous_error}") from previous_error
+                _revoke_stored_oauth(previous_oauth)
+            except OAuthError as previous_error:
+                try:
+                    _revoke_stored_oauth(replacement_oauth)
+                except OAuthError as cleanup_error:
+                    raise OAuthError(
+                        f"Could not replace the previous OAuth session: {previous_error} "
+                        f"The new OAuth session also could not be revoked: {cleanup_error}"
+                    ) from previous_error
+                raise OAuthError(f"Could not replace the previous OAuth session: {previous_error}") from previous_error
 
-    config.pop("api_key", None)
-    config["oauth"] = replacement_oauth
-    _write_config(config)
+        config.pop("api_key", None)
+        config["oauth"] = replacement_oauth
+        _write_config_unlocked(config)
 
 
 def _save_refreshed_oauth_session(session) -> None:
     """Persist refreshed tokens for the active session without revoking it."""
-    config = _read_config()
-    config.pop("api_key", None)
-    config["oauth"] = _oauth_session_data(session)
-    _write_config(config)
+    with _config_lock():
+        config = _read_config()
+        config.pop("api_key", None)
+        config["oauth"] = _oauth_session_data(session)
+        _write_config_unlocked(config)
 
 
 def has_stored_oauth() -> bool:
@@ -198,27 +284,28 @@ def get_api_base_url() -> str | None:
 
 
 def clear_credentials() -> ClearCredentialsResult:
-    oauth = _read_config().get("oauth")
-    server_revoked: bool | None = None
-    revocation_error: str | None = None
-    if isinstance(oauth, dict):
-        try:
-            if _revoke_stored_oauth(oauth):
-                server_revoked = True
-        except Exception as e:
-            # Logout must still remove local credentials even when the remote
-            # session cannot be revoked. Return the failure to the command so it
-            # can report a partial result and exit non-zero.
-            server_revoked = False
-            revocation_error = str(e) or e.__class__.__name__
-    if CONFIG_FILE.exists():
+    with _config_lock():
         config = _read_config()
-        config.pop("api_key", None)
-        config.pop("oauth", None)
-        if config:
-            _write_config(config)
-        else:
-            CONFIG_FILE.unlink()
+        oauth = config.get("oauth")
+        server_revoked: bool | None = None
+        revocation_error: str | None = None
+        if isinstance(oauth, dict):
+            try:
+                if _revoke_stored_oauth(oauth):
+                    server_revoked = True
+            except Exception as e:
+                # Logout must still remove local credentials even when the remote
+                # session cannot be revoked. Return the failure to the command so it
+                # can report a partial result and exit non-zero.
+                server_revoked = False
+                revocation_error = str(e) or e.__class__.__name__
+        if CONFIG_FILE.exists():
+            config.pop("api_key", None)
+            config.pop("oauth", None)
+            if config:
+                _write_config_unlocked(config)
+            else:
+                CONFIG_FILE.unlink()
     _clear_mcp_tokens()
     return ClearCredentialsResult(
         local_credentials_cleared=True,
@@ -354,8 +441,9 @@ def _revoke_stored_oauth(data: dict) -> bool:
 
 
 def _get_oauth_access_token(config: dict) -> str | None:
-    """Return a usable OAuth access token from config, refreshing if needed."""
+    """Return a usable OAuth access token; get_api_key holds the transaction lock."""
     from tavily_cli.oauth import (
+        OAuthError,
         OAuthSession,
         fetch_metadata,
         refresh_tokens,
@@ -379,8 +467,12 @@ def _get_oauth_access_token(config: dict) -> str | None:
         tokens = refresh_tokens(fetch_metadata(), client, refresh)
         _save_refreshed_oauth_session(OAuthSession(tokens=tokens, client=client))
         return tokens.access_token
-    except Exception:
-        return None
+    except Exception as e:
+        raise OAuthError(
+            "Could not refresh the stored Tavily OAuth session. "
+            "The stored credentials were not removed; retry the command, and run `tvly login` only if it continues. "
+            f"Details: {e}"
+        ) from e
 
 
 def get_api_key() -> str | None:
@@ -389,14 +481,15 @@ def get_api_key() -> str | None:
     if key:
         return key
 
-    config = _read_config()
-    key = config.get("api_key")
-    if key:
-        return key
+    with _config_lock():
+        config = _read_config()
+        key = config.get("api_key")
+        if key:
+            return key
 
-    token = _get_oauth_access_token(config)
-    if token:
-        return token
+        token = _get_oauth_access_token(config)
+        if token:
+            return token
 
     return _get_mcp_token()
 
@@ -406,11 +499,18 @@ def is_oauth_token(key: str) -> bool:
     return not key.startswith("tvly-") and _decode_jwt_payload(key) is not None
 
 
-def get_api_key_or_exit() -> str:
+def get_api_key_or_exit(*, json_mode: bool = False) -> str:
     """Get the API key or print an error and exit."""
     import sys
 
-    key = get_api_key()
+    from tavily_cli.oauth import OAuthError
+
+    try:
+        key = get_api_key()
+    except OAuthError as e:
+        from tavily_cli.common import handle_oauth_refresh_error
+
+        handle_oauth_refresh_error(e, json_mode)
     if not key:
         from rich.console import Console
         console = Console(stderr=True)
@@ -426,9 +526,9 @@ def get_api_key_or_exit() -> str:
     return key
 
 
-def get_client(client_name: str | None = None):
+def get_client(client_name: str | None = None, *, json_mode: bool = False):
     """Return the appropriate Tavily client (SDK or MCP) based on credential type."""
-    key = get_api_key_or_exit()
+    key = get_api_key_or_exit(json_mode=json_mode)
     return _build_keyed_client(key, client_name=client_name)
 
 
@@ -472,11 +572,18 @@ def get_client_or_keyless(client_name: str | None = None):
     )
 
 
-def require_api_key_friendly(command_name: str) -> str:
+def require_api_key_friendly(command_name: str, *, json_mode: bool = False) -> str:
     """Return the API key, or print a friendly message and exit non-zero."""
     import sys
 
-    key = get_api_key()
+    from tavily_cli.oauth import OAuthError
+
+    try:
+        key = get_api_key()
+    except OAuthError as e:
+        from tavily_cli.common import handle_oauth_refresh_error
+
+        handle_oauth_refresh_error(e, json_mode)
     if key:
         return key
 

--- a/tavily_cli/config.py
+++ b/tavily_cli/config.py
@@ -109,22 +109,13 @@ def _write_config(data: dict) -> None:
         os.umask(old_umask)
 
 
-def save_api_key(api_key: str) -> None:
-    config = _read_config()
-    config["api_key"] = api_key
-    config.pop("oauth", None)
-    _write_config(config)
-
-
-def save_oauth_session(session) -> None:
-    """Persist OAuth tokens and the dynamically registered client in config.json."""
+def _oauth_session_data(session) -> dict:
+    """Serialize a validated OAuth session for config.json."""
     from tavily_cli.oauth import OAuthSession
 
     if not isinstance(session, OAuthSession):
         raise TypeError("session must be an OAuthSession")
-    config = _read_config()
-    config.pop("api_key", None)
-    config["oauth"] = {
+    return {
         "access_token": session.tokens.access_token,
         "refresh_token": session.tokens.refresh_token,
         "expires_at": session.tokens.expires_at,
@@ -134,6 +125,49 @@ def save_oauth_session(session) -> None:
         "token_endpoint_auth_method": session.client.token_endpoint_auth_method,
         "redirect_uri": session.client.redirect_uri,
     }
+
+
+def save_api_key(api_key: str) -> None:
+    """Replace stored credentials with an API key, revoking old OAuth first."""
+    config = _read_config()
+    previous_oauth = config.get("oauth")
+    if isinstance(previous_oauth, dict):
+        _revoke_stored_oauth(previous_oauth)
+    config["api_key"] = api_key
+    config.pop("oauth", None)
+    _write_config(config)
+
+
+def save_oauth_session(session) -> None:
+    """Replace stored credentials with a newly authorized OAuth session."""
+    from tavily_cli.oauth import OAuthError
+
+    replacement_oauth = _oauth_session_data(session)
+    config = _read_config()
+    previous_oauth = config.get("oauth")
+    if isinstance(previous_oauth, dict) and previous_oauth != replacement_oauth:
+        try:
+            _revoke_stored_oauth(previous_oauth)
+        except OAuthError as previous_error:
+            try:
+                _revoke_stored_oauth(replacement_oauth)
+            except OAuthError as cleanup_error:
+                raise OAuthError(
+                    f"Could not replace the previous OAuth session: {previous_error} "
+                    f"The new OAuth session also could not be revoked: {cleanup_error}"
+                ) from previous_error
+            raise OAuthError(f"Could not replace the previous OAuth session: {previous_error}") from previous_error
+
+    config.pop("api_key", None)
+    config["oauth"] = replacement_oauth
+    _write_config(config)
+
+
+def _save_refreshed_oauth_session(session) -> None:
+    """Persist refreshed tokens for the active session without revoking it."""
+    config = _read_config()
+    config.pop("api_key", None)
+    config["oauth"] = _oauth_session_data(session)
     _write_config(config)
 
 
@@ -343,7 +377,7 @@ def _get_oauth_access_token(config: dict) -> str | None:
         return None
     try:
         tokens = refresh_tokens(fetch_metadata(), client, refresh)
-        save_oauth_session(OAuthSession(tokens=tokens, client=client))
+        _save_refreshed_oauth_session(OAuthSession(tokens=tokens, client=client))
         return tokens.access_token
     except Exception:
         return None

--- a/tavily_cli/config.py
+++ b/tavily_cli/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from uuid import uuid4
 
@@ -14,6 +15,15 @@ CONFIG_FILE = CONFIG_DIR / "config.json"
 _SESSION_FILE = CONFIG_DIR / "session.json"
 
 MCP_AUTH_DIR = Path.home() / ".mcp-auth"
+
+
+@dataclass(frozen=True)
+class ClearCredentialsResult:
+    """Outcome of local credential cleanup and optional server revocation."""
+
+    local_credentials_cleared: bool
+    server_revoked: bool | None
+    revocation_error: str | None = None
 
 
 def _pid_alive(pid: int) -> bool:
@@ -153,10 +163,20 @@ def get_api_base_url() -> str | None:
     return configured.rstrip("/") if configured else None
 
 
-def clear_credentials() -> None:
+def clear_credentials() -> ClearCredentialsResult:
     oauth = _read_config().get("oauth")
+    server_revoked: bool | None = None
+    revocation_error: str | None = None
     if isinstance(oauth, dict):
-        _revoke_stored_oauth(oauth)
+        try:
+            if _revoke_stored_oauth(oauth):
+                server_revoked = True
+        except Exception as e:
+            # Logout must still remove local credentials even when the remote
+            # session cannot be revoked. Return the failure to the command so it
+            # can report a partial result and exit non-zero.
+            server_revoked = False
+            revocation_error = str(e) or e.__class__.__name__
     if CONFIG_FILE.exists():
         config = _read_config()
         config.pop("api_key", None)
@@ -166,6 +186,11 @@ def clear_credentials() -> None:
         else:
             CONFIG_FILE.unlink()
     _clear_mcp_tokens()
+    return ClearCredentialsResult(
+        local_credentials_cleared=True,
+        server_revoked=server_revoked,
+        revocation_error=revocation_error,
+    )
 
 
 def _decode_jwt_payload(token: str) -> dict | None:
@@ -256,21 +281,42 @@ def _oauth_client_from_dict(data: dict):
     )
 
 
-def _revoke_stored_oauth(data: dict) -> None:
-    """Best-effort token revocation. Never raises — logout must still clear disk."""
-    from tavily_cli.oauth import fetch_metadata, revoke_token
+def _revoke_stored_oauth(data: dict) -> bool:
+    """Revoke stored refresh/access tokens, returning whether any were attempted."""
+    from tavily_cli.oauth import OAuthError, fetch_metadata, revoke_token
+
+    tokens = [
+        ("refresh_token", "refresh_token"),
+        ("access_token", "access_token"),
+    ]
+    present_tokens = [
+        (key, token_type_hint, data.get(key))
+        for key, token_type_hint in tokens
+        if isinstance(data.get(key), str) and data.get(key)
+    ]
+    if not present_tokens:
+        return False
 
     client = _oauth_client_from_dict(data)
     if client is None:
-        return
-    try:
-        metadata = fetch_metadata()
-        for key in ("access_token", "refresh_token"):
-            token = data.get(key)
-            if isinstance(token, str) and token:
-                revoke_token(metadata, client, token)
-    except Exception:
-        return
+        raise OAuthError("Stored OAuth client metadata is incomplete; server revocation was not attempted.")
+
+    metadata = fetch_metadata()
+    errors: list[str] = []
+    for key, token_type_hint, token in present_tokens:
+        try:
+            revoke_token(
+                metadata,
+                client,
+                token,
+                token_type_hint=token_type_hint,
+            )
+        except OAuthError as e:
+            errors.append(f"{key}: {e}")
+
+    if errors:
+        raise OAuthError("; ".join(errors))
+    return True
 
 
 def _get_oauth_access_token(config: dict) -> str | None:

--- a/tavily_cli/init_skills.py
+++ b/tavily_cli/init_skills.py
@@ -14,8 +14,10 @@ from uuid import uuid4
 
 import httpx
 
-SKILLS_SOURCE = "tavily-ai/skills"
-SKILLS_ARCHIVE_URL = "https://codeload.github.com/tavily-ai/skills/tar.gz/refs/heads/main"
+SKILLS_COMMIT = "ea5e8201b0d3ed9c10b70b71187589bd761fe2d2"
+SKILLS_ARCHIVE_SHA256 = "a6d304afa7f4274dd307fb02917fd04d23771610fb828f2a7463d5745eccf804"
+SKILLS_SOURCE = f"tavily-ai/skills@{SKILLS_COMMIT}"
+SKILLS_ARCHIVE_URL = f"https://codeload.github.com/tavily-ai/skills/tar.gz/{SKILLS_COMMIT}"
 CORE_SKILLS = (
     "tavily-best-practices",
     "tavily-cli",
@@ -86,7 +88,10 @@ def download_skills_archive(*, client: httpx.Client | None = None) -> bytes:
                 if size > _MAX_ARCHIVE_BYTES:
                     raise ValueError("Tavily skills archive exceeds the 25 MB safety limit.")
                 chunks.append(chunk)
-        return b"".join(chunks)
+        archive = b"".join(chunks)
+        if hashlib.sha256(archive).hexdigest() != SKILLS_ARCHIVE_SHA256:
+            raise ValueError("Downloaded Tavily skills archive failed integrity verification.")
+        return archive
     finally:
         if close:
             http.close()
@@ -211,7 +216,9 @@ def _extract_core_skills(archive_data: bytes, destination: Path) -> None:
                 raise ValueError(f"Could not read {member.name} from the Tavily skills archive.")
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_bytes(source.read())
-            target.chmod(0o755 if member.mode & 0o111 else 0o644)
+            # Skill payloads are data consumed by agents, not trusted programs.
+            # Never propagate executable bits supplied by the archive.
+            target.chmod(0o644)
             found.add(skill_name)
 
     missing = [name for name in CORE_SKILLS if name not in found or not (destination / name / "SKILL.md").is_file()]

--- a/tavily_cli/init_skills.py
+++ b/tavily_cli/init_skills.py
@@ -1,0 +1,313 @@
+"""Install Tavily's maintained agent skills without requiring Node.js."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import shutil
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from uuid import uuid4
+
+import httpx
+
+SKILLS_SOURCE = "tavily-ai/skills"
+SKILLS_ARCHIVE_URL = "https://codeload.github.com/tavily-ai/skills/tar.gz/refs/heads/main"
+CORE_SKILLS = (
+    "tavily-best-practices",
+    "tavily-cli",
+    "tavily-crawl",
+    "tavily-dynamic-search",
+    "tavily-extract",
+    "tavily-map",
+    "tavily-research",
+    "tavily-search",
+)
+
+_MAX_ARCHIVE_BYTES = 25 * 1024 * 1024
+_MAX_FILE_BYTES = 5 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    marker: Path
+    skills_dir: Path
+
+
+@dataclass(frozen=True)
+class SkillsInstallResult:
+    agents: tuple[str, ...]
+    installed: int
+    updated: int
+    unchanged: int
+    linked: int
+    restart_required: bool
+
+    @property
+    def total(self) -> int:
+        return self.installed + self.updated + self.unchanged
+
+
+def agent_specs(home: Path | None = None) -> dict[str, AgentSpec]:
+    """Return supported agent locations rooted at the current user's home."""
+    root = home or Path.home()
+    if home is None:
+        claude_root = Path(os.environ.get("CLAUDE_CONFIG_DIR", root / ".claude")).expanduser()
+        codex_root = Path(os.environ.get("CODEX_HOME", root / ".codex")).expanduser()
+    else:
+        claude_root = root / ".claude"
+        codex_root = root / ".codex"
+    return {
+        "claude-code": AgentSpec(claude_root, claude_root / "skills"),
+        "codex": AgentSpec(codex_root, codex_root / "skills"),
+        "cursor": AgentSpec(root / ".cursor", root / ".cursor" / "skills"),
+    }
+
+
+def detect_agents(home: Path | None = None) -> tuple[str, ...]:
+    """Detect supported agents from their existing configuration directories."""
+    return tuple(name for name, spec in agent_specs(home).items() if spec.marker.is_dir())
+
+
+def download_skills_archive(*, client: httpx.Client | None = None) -> bytes:
+    """Download the canonical skills archive with a conservative size limit."""
+    http = client or httpx.Client(timeout=30.0, follow_redirects=True)
+    close = client is None
+    try:
+        chunks: list[bytes] = []
+        size = 0
+        with http.stream("GET", SKILLS_ARCHIVE_URL) as response:
+            response.raise_for_status()
+            for chunk in response.iter_bytes():
+                size += len(chunk)
+                if size > _MAX_ARCHIVE_BYTES:
+                    raise ValueError("Tavily skills archive exceeds the 25 MB safety limit.")
+                chunks.append(chunk)
+        return b"".join(chunks)
+    finally:
+        if close:
+            http.close()
+
+
+def install_skills(
+    agents: tuple[str, ...],
+    *,
+    home: Path | None = None,
+    archive: bytes | None = None,
+) -> SkillsInstallResult:
+    """Install the eight core skills and expose them to selected agents.
+
+    Archive scripts and references are copied as files but are never executed.
+    Only the exact Tavily skill names in ``CORE_SKILLS`` are managed.
+    """
+    root = home or Path.home()
+    specs = agent_specs(home)
+    unsupported = sorted(set(agents) - set(specs))
+    if unsupported:
+        raise ValueError(f"Unsupported agent(s): {', '.join(unsupported)}")
+
+    shared_root = root / ".agents" / "skills"
+    shared_root.mkdir(parents=True, exist_ok=True)
+
+    installed = 0
+    updated = 0
+    unchanged = 0
+    linked = 0
+    archive_data = archive if archive is not None else download_skills_archive()
+
+    with tempfile.TemporaryDirectory(prefix="tavily-skills-") as temp_dir:
+        extracted_root = Path(temp_dir)
+        _extract_core_skills(archive_data, extracted_root)
+        _preflight_install(shared_root, agents, specs)
+
+        for skill_name in CORE_SKILLS:
+            source = extracted_root / skill_name
+            destination = shared_root / skill_name
+            state = _replace_if_changed(source, destination)
+            if state == "installed":
+                installed += 1
+            elif state == "updated":
+                updated += 1
+            else:
+                unchanged += 1
+
+        for agent_name in agents:
+            skills_dir = specs[agent_name].skills_dir
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            for skill_name in CORE_SKILLS:
+                if _expose_skill(shared_root / skill_name, skills_dir / skill_name):
+                    linked += 1
+
+    changed = installed > 0 or updated > 0 or linked > 0
+    return SkillsInstallResult(
+        agents=agents,
+        installed=installed,
+        updated=updated,
+        unchanged=unchanged,
+        linked=linked,
+        restart_required=changed,
+    )
+
+
+def verify_skills(agents: tuple[str, ...], *, home: Path | None = None) -> bool:
+    """Verify shared skill files and selected agent entries are present."""
+    root = home or Path.home()
+    specs = agent_specs(home)
+    shared_root = root / ".agents" / "skills"
+    for skill_name in CORE_SKILLS:
+        if not (shared_root / skill_name / "SKILL.md").is_file():
+            return False
+    for agent_name in agents:
+        spec = specs.get(agent_name)
+        if spec is None:
+            return False
+        for skill_name in CORE_SKILLS:
+            if not (spec.skills_dir / skill_name / "SKILL.md").is_file():
+                return False
+    return True
+
+
+def _extract_core_skills(archive_data: bytes, destination: Path) -> None:
+    """Extract only approved skill directories from an untrusted tar archive."""
+    found: set[str] = set()
+    total_file_bytes = 0
+    try:
+        archive = tarfile.open(fileobj=io.BytesIO(archive_data), mode="r:gz")
+    except tarfile.TarError as exc:
+        raise ValueError("Downloaded Tavily skills archive is invalid.") from exc
+
+    with archive:
+        for member in archive.getmembers():
+            path = PurePosixPath(member.name)
+            parts = path.parts
+            if path.is_absolute() or ".." in parts or len(parts) < 4:
+                continue
+            if parts[1] != "skills" or parts[2] not in CORE_SKILLS:
+                continue
+
+            skill_name = parts[2]
+            relative_parts = parts[3:]
+            if not relative_parts:
+                continue
+            if any(part in ("", ".", "..") or "\\" in part or ":" in part for part in relative_parts):
+                raise ValueError(f"Tavily skill {skill_name} contains an unsafe archive path.")
+            target = destination / skill_name / Path(*relative_parts)
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            if not member.isfile():
+                raise ValueError(f"Tavily skill {skill_name} contains an unsupported archive entry.")
+            if member.size > _MAX_FILE_BYTES:
+                raise ValueError(f"Tavily skill {skill_name} contains a file larger than 5 MB.")
+            total_file_bytes += member.size
+            if total_file_bytes > _MAX_ARCHIVE_BYTES:
+                raise ValueError("Extracted Tavily skills exceed the 25 MB safety limit.")
+
+            source = archive.extractfile(member)
+            if source is None:
+                raise ValueError(f"Could not read {member.name} from the Tavily skills archive.")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(source.read())
+            target.chmod(0o755 if member.mode & 0o111 else 0o644)
+            found.add(skill_name)
+
+    missing = [name for name in CORE_SKILLS if name not in found or not (destination / name / "SKILL.md").is_file()]
+    if missing:
+        raise ValueError(f"Tavily skills archive is missing: {', '.join(missing)}")
+
+
+def _directory_digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    entries = sorted(path.rglob("*"))
+    if any(item.is_symlink() for item in entries):
+        raise ValueError(f"Cannot compare a skill containing links: {path}")
+    for file_path in (item for item in entries if item.is_file()):
+        relative = file_path.relative_to(path).as_posix().encode("utf-8")
+        content = file_path.read_bytes()
+        digest.update(len(relative).to_bytes(4, "big"))
+        digest.update(relative)
+        digest.update((file_path.stat().st_mode & 0o111).to_bytes(2, "big"))
+        digest.update(len(content).to_bytes(8, "big"))
+        digest.update(content)
+    return digest.hexdigest()
+
+
+def _replace_if_changed(source: Path, destination: Path) -> str:
+    existed = destination.exists() or destination.is_symlink()
+    if destination.is_dir() and not destination.is_symlink():
+        if _directory_digest(source) == _directory_digest(destination):
+            return "unchanged"
+    elif existed:
+        raise ValueError(f"Cannot install Tavily skill over non-directory path: {destination}")
+
+    token = uuid4().hex
+    staging = destination.parent / f".{destination.name}.tavily-new-{token}"
+    backup = destination.parent / f".{destination.name}.tavily-backup-{token}"
+
+    shutil.copytree(source, staging)
+    try:
+        if existed:
+            destination.replace(backup)
+        staging.replace(destination)
+    except Exception:
+        if not destination.exists() and backup.exists():
+            backup.replace(destination)
+        raise
+    else:
+        if backup.exists() or backup.is_symlink():
+            try:
+                _remove_path(backup)
+            except OSError:
+                pass
+    finally:
+        if staging.exists() or staging.is_symlink():
+            _remove_path(staging)
+    return "updated" if existed else "installed"
+
+
+def _expose_skill(source: Path, destination: Path) -> bool:
+    if destination.is_symlink():
+        if destination.resolve(strict=False) == source.resolve():
+            return False
+        raise ValueError(f"Cannot replace existing skill link: {destination}")
+    if destination.exists():
+        if not destination.is_dir():
+            raise ValueError(f"Cannot replace non-directory skill path: {destination}")
+        return _replace_if_changed(source, destination) != "unchanged"
+
+    relative_source = os.path.relpath(source, start=destination.parent)
+    try:
+        destination.symlink_to(relative_source, target_is_directory=True)
+    except OSError:
+        shutil.copytree(source, destination)
+    return True
+
+
+def _preflight_install(shared_root: Path, agents: tuple[str, ...], specs: dict[str, AgentSpec]) -> None:
+    """Reject path conflicts before changing any installed skill."""
+    for skill_name in CORE_SKILLS:
+        destination = shared_root / skill_name
+        if (destination.exists() or destination.is_symlink()) and (
+            destination.is_symlink() or not destination.is_dir()
+        ):
+            raise ValueError(f"Cannot install Tavily skill over non-directory path: {destination}")
+
+    for agent_name in agents:
+        for skill_name in CORE_SKILLS:
+            source = shared_root / skill_name
+            destination = specs[agent_name].skills_dir / skill_name
+            if destination.is_symlink():
+                if destination.resolve(strict=False) != source.resolve(strict=False):
+                    raise ValueError(f"Cannot replace existing skill link: {destination}")
+            elif destination.exists() and not destination.is_dir():
+                raise ValueError(f"Cannot replace non-directory skill path: {destination}")
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)

--- a/tavily_cli/mcp_client.py
+++ b/tavily_cli/mcp_client.py
@@ -105,8 +105,8 @@ def _call_mcp_tool(
         if "error" in data:
             raise RuntimeError(data["error"].get("message", str(data["error"])))
         return data.get("result", data)
-    except json.JSONDecodeError:
-        raise RuntimeError(f"Unexpected MCP response: {text[:500]}")
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"Unexpected MCP response: {text[:500]}") from e
 
 
 class McpTavilyClient:

--- a/tavily_cli/oauth.py
+++ b/tavily_cli/oauth.py
@@ -19,6 +19,7 @@ import webbrowser
 from collections.abc import Callable
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Literal
 
 import httpx
 
@@ -271,19 +272,38 @@ def revoke_token(
     registered: RegisteredClient,
     token: str,
     *,
+    token_type_hint: Literal["access_token", "refresh_token"],
     client: httpx.Client | None = None,
 ) -> None:
-    if not metadata.revocation_endpoint or not token:
+    if not token:
         return
+    if not metadata.revocation_endpoint:
+        raise OAuthError("OAuth server does not advertise a token revocation endpoint.")
+
     http = client or httpx.Client(timeout=HTTP_TIMEOUT)
     close = client is None
-    body = {"token": token}
+    body = {
+        "token": token,
+        "token_type_hint": token_type_hint,
+    }
     extra, basic = _token_auth_extras(registered)
     body.update(extra)
     try:
-        http.post(metadata.revocation_endpoint, data=body, auth=basic)
-    except httpx.HTTPError:
-        pass
+        resp = http.post(metadata.revocation_endpoint, data=body, auth=basic)
+
+        if resp.status_code == 400 and registered.token_endpoint_auth_method == "none":
+            # Compatibility fallback for MCP Python SDK revocation handlers that
+            # incorrectly require the nullable client_secret form field. The
+            # registered client remains public and no secret is supplied.
+            # https://github.com/modelcontextprotocol/python-sdk/issues/2260
+            compatibility_body = dict(body)
+            compatibility_body["client_secret"] = ""
+            resp = http.post(metadata.revocation_endpoint, data=compatibility_body, auth=basic)
+
+        if not resp.is_success:
+            raise OAuthError(_http_error("Token revocation failed", resp))
+    except httpx.HTTPError as e:
+        raise OAuthError(f"Could not reach the Tavily OAuth server: {e}") from e
     finally:
         if close:
             http.close()

--- a/tavily_cli/oauth.py
+++ b/tavily_cli/oauth.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import math
 import secrets
 import string
 import threading
@@ -92,8 +93,13 @@ def expires_at_from_now(expires_in: int | None, *, now: float | None = None) -> 
     return (now if now is not None else time.time()) + lifetime - _EXPIRY_SKEW_SECONDS
 
 
-def token_is_expired(expires_at: float | None, *, now: float | None = None) -> bool:
-    if expires_at is None:
+def token_is_expired(expires_at: object, *, now: float | None = None) -> bool:
+    """Treat missing, malformed, and non-finite stored expiries as expired."""
+    if (
+        isinstance(expires_at, bool)
+        or not isinstance(expires_at, (int, float))
+        or not math.isfinite(expires_at)
+    ):
         return True
     return (now if now is not None else time.time()) >= expires_at
 

--- a/tavily_cli/oauth.py
+++ b/tavily_cli/oauth.py
@@ -1,0 +1,440 @@
+"""Native MCP OAuth 2.1 for the Tavily CLI.
+
+Replaces the previous `npx mcp-remote` login path. Speaks the authorization
+code + PKCE flow that https://mcp.tavily.com/ advertises (dynamic client
+registration, refresh tokens). Tokens are stored in ~/.tavily/config.json.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import secrets
+import string
+import threading
+import time
+import urllib.parse
+import webbrowser
+from collections.abc import Callable
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import httpx
+
+MCP_ISSUER = "https://mcp.tavily.com/"
+MCP_RESOURCE = "https://mcp.tavily.com/mcp"
+OAUTH_METADATA_URL = "https://mcp.tavily.com/.well-known/oauth-authorization-server"
+PRM_URL = "https://mcp.tavily.com/.well-known/oauth-protected-resource/mcp"
+DEFAULT_SCOPES = "openid offline_access"
+CLIENT_NAME = "Tavily CLI"
+LOGIN_TIMEOUT_SECONDS = 180
+HTTP_TIMEOUT = 30.0
+_EXPIRY_SKEW_SECONDS = 60
+
+_FALLBACK_METADATA = {
+    "issuer": MCP_ISSUER,
+    "authorization_endpoint": "https://mcp.tavily.com/authorize",
+    "token_endpoint": "https://mcp.tavily.com/token",
+    "registration_endpoint": "https://mcp.tavily.com/register",
+    "revocation_endpoint": "https://mcp.tavily.com/revoke",
+}
+
+
+class OAuthError(Exception):
+    """Interactive OAuth failed in a way the CLI should show to the user."""
+
+
+@dataclass
+class OAuthMetadata:
+    authorization_endpoint: str
+    token_endpoint: str
+    registration_endpoint: str
+    revocation_endpoint: str | None
+    resource: str = MCP_RESOURCE
+
+
+@dataclass
+class RegisteredClient:
+    client_id: str
+    client_secret: str | None
+    token_endpoint_auth_method: str
+    redirect_uri: str
+
+
+@dataclass
+class OAuthTokens:
+    access_token: str
+    refresh_token: str | None
+    expires_at: float
+    token_type: str = "Bearer"
+
+
+@dataclass
+class OAuthSession:
+    tokens: OAuthTokens
+    client: RegisteredClient
+
+
+def generate_pkce() -> tuple[str, str]:
+    """Return (code_verifier, code_challenge) for S256 PKCE."""
+    alphabet = string.ascii_letters + string.digits + "-._~"
+    verifier = "".join(secrets.choice(alphabet) for _ in range(128))
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+    return verifier, challenge
+
+
+def expires_at_from_now(expires_in: int | None, *, now: float | None = None) -> float:
+    """Unix timestamp when the access token should be treated as expired."""
+    lifetime = expires_in if isinstance(expires_in, int) and expires_in > 0 else 3600
+    return (now if now is not None else time.time()) + lifetime - _EXPIRY_SKEW_SECONDS
+
+
+def token_is_expired(expires_at: float | None, *, now: float | None = None) -> bool:
+    if expires_at is None:
+        return True
+    return (now if now is not None else time.time()) >= expires_at
+
+
+def fetch_metadata(client: httpx.Client | None = None) -> OAuthMetadata:
+    """Discover AS + resource metadata, with static fallbacks if discovery fails."""
+    http = client or httpx.Client(timeout=HTTP_TIMEOUT)
+    close = client is None
+    try:
+        data = dict(_FALLBACK_METADATA)
+        try:
+            resp = http.get(OAUTH_METADATA_URL)
+            resp.raise_for_status()
+            discovered = resp.json()
+            if isinstance(discovered, dict):
+                data.update({k: v for k, v in discovered.items() if isinstance(v, str)})
+        except (httpx.HTTPError, json.JSONDecodeError, ValueError):
+            pass
+
+        resource = MCP_RESOURCE
+        try:
+            resp = http.get(PRM_URL)
+            if resp.is_success:
+                prm = resp.json()
+                if isinstance(prm, dict) and isinstance(prm.get("resource"), str):
+                    resource = prm["resource"]
+        except (httpx.HTTPError, json.JSONDecodeError, ValueError):
+            pass
+
+        registration = data.get("registration_endpoint")
+        authorization = data.get("authorization_endpoint")
+        token = data.get("token_endpoint")
+        if not registration or not authorization or not token:
+            raise OAuthError("OAuth discovery did not return authorization, token, and registration endpoints.")
+        return OAuthMetadata(
+            authorization_endpoint=authorization,
+            token_endpoint=token,
+            registration_endpoint=registration,
+            revocation_endpoint=data.get("revocation_endpoint"),
+            resource=resource,
+        )
+    finally:
+        if close:
+            http.close()
+
+
+def register_client(
+    metadata: OAuthMetadata,
+    redirect_uri: str,
+    *,
+    client: httpx.Client | None = None,
+) -> RegisteredClient:
+    """RFC 7591 dynamic client registration as a public PKCE client."""
+    http = client or httpx.Client(timeout=HTTP_TIMEOUT)
+    close = client is None
+    payload = {
+        "client_name": CLIENT_NAME,
+        "redirect_uris": [redirect_uri],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+        "scope": DEFAULT_SCOPES,
+        "application_type": "native",
+    }
+    try:
+        resp = http.post(metadata.registration_endpoint, json=payload)
+        if resp.status_code >= 400:
+            raise OAuthError(_http_error("Client registration failed", resp))
+        data = resp.json()
+        client_id = data.get("client_id")
+        if not isinstance(client_id, str) or not client_id:
+            raise OAuthError("OAuth registration did not return a client_id.")
+        method = data.get("token_endpoint_auth_method") or "none"
+        if method not in ("none", "client_secret_post", "client_secret_basic"):
+            raise OAuthError(
+                f"Authorization server registered the CLI with unsupported "
+                f"token_endpoint_auth_method {method!r}."
+            )
+        secret = data.get("client_secret")
+        if method in ("client_secret_post", "client_secret_basic") and not secret:
+            raise OAuthError(
+                f"Authorization server registered the CLI for {method!r} but issued no client_secret."
+            )
+        return RegisteredClient(
+            client_id=client_id,
+            client_secret=secret if isinstance(secret, str) else None,
+            token_endpoint_auth_method=method,
+            redirect_uri=redirect_uri,
+        )
+    except httpx.HTTPError as e:
+        raise OAuthError(f"Could not reach the Tavily OAuth server: {e}") from e
+    finally:
+        if close:
+            http.close()
+
+
+def build_authorize_url(
+    metadata: OAuthMetadata,
+    registered: RegisteredClient,
+    *,
+    state: str,
+    code_challenge: str,
+) -> str:
+    params = {
+        "response_type": "code",
+        "client_id": registered.client_id,
+        "redirect_uri": registered.redirect_uri,
+        "scope": DEFAULT_SCOPES,
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "resource": metadata.resource,
+    }
+    return metadata.authorization_endpoint + "?" + urllib.parse.urlencode(params)
+
+
+def _token_auth_extras(registered: RegisteredClient) -> tuple[dict[str, str], tuple[str, str] | None]:
+    """Body fields and optional basic-auth tuple for the token/revoke endpoints."""
+    extra: dict[str, str] = {"client_id": registered.client_id}
+    basic = None
+    if registered.token_endpoint_auth_method == "client_secret_post" and registered.client_secret:
+        extra["client_secret"] = registered.client_secret
+    elif registered.token_endpoint_auth_method == "client_secret_basic" and registered.client_secret:
+        basic = (registered.client_id, registered.client_secret)
+        extra = {}
+    return extra, basic
+
+
+def exchange_code(
+    metadata: OAuthMetadata,
+    registered: RegisteredClient,
+    *,
+    code: str,
+    code_verifier: str,
+    client: httpx.Client | None = None,
+) -> OAuthTokens:
+    body = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": registered.redirect_uri,
+        "code_verifier": code_verifier,
+        "resource": metadata.resource,
+    }
+    extra, basic = _token_auth_extras(registered)
+    body.update(extra)
+    return _request_tokens(metadata.token_endpoint, body, basic=basic, client=client)
+
+
+def refresh_tokens(
+    metadata: OAuthMetadata,
+    registered: RegisteredClient,
+    refresh_token: str,
+    *,
+    client: httpx.Client | None = None,
+) -> OAuthTokens:
+    body = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "resource": metadata.resource,
+    }
+    extra, basic = _token_auth_extras(registered)
+    body.update(extra)
+    tokens = _request_tokens(metadata.token_endpoint, body, basic=basic, client=client)
+    if tokens.refresh_token is None:
+        tokens = OAuthTokens(
+            access_token=tokens.access_token,
+            refresh_token=refresh_token,
+            expires_at=tokens.expires_at,
+            token_type=tokens.token_type,
+        )
+    return tokens
+
+
+def revoke_token(
+    metadata: OAuthMetadata,
+    registered: RegisteredClient,
+    token: str,
+    *,
+    client: httpx.Client | None = None,
+) -> None:
+    if not metadata.revocation_endpoint or not token:
+        return
+    http = client or httpx.Client(timeout=HTTP_TIMEOUT)
+    close = client is None
+    body = {"token": token}
+    extra, basic = _token_auth_extras(registered)
+    body.update(extra)
+    try:
+        http.post(metadata.revocation_endpoint, data=body, auth=basic)
+    except httpx.HTTPError:
+        pass
+    finally:
+        if close:
+            http.close()
+
+
+def _request_tokens(
+    token_endpoint: str,
+    body: dict[str, str],
+    *,
+    basic: tuple[str, str] | None,
+    client: httpx.Client | None,
+) -> OAuthTokens:
+    http = client or httpx.Client(timeout=HTTP_TIMEOUT)
+    close = client is None
+    try:
+        resp = http.post(token_endpoint, data=body, auth=basic)
+        if resp.status_code >= 400:
+            raise OAuthError(_http_error("Token request failed", resp))
+        data = resp.json()
+        access = data.get("access_token")
+        if not isinstance(access, str) or not access:
+            raise OAuthError("OAuth token response did not include an access_token.")
+        refresh = data.get("refresh_token")
+        return OAuthTokens(
+            access_token=access,
+            refresh_token=refresh if isinstance(refresh, str) else None,
+            expires_at=expires_at_from_now(data.get("expires_in")),
+            token_type=data.get("token_type") or "Bearer",
+        )
+    except httpx.HTTPError as e:
+        raise OAuthError(f"Could not reach the Tavily OAuth server: {e}") from e
+    finally:
+        if close:
+            http.close()
+
+
+def _http_error(prefix: str, resp: httpx.Response) -> str:
+    detail = resp.text.strip().replace("\n", " ")
+    if len(detail) > 280:
+        detail = detail[:277] + "..."
+    if detail:
+        return f"{prefix} (HTTP {resp.status_code}): {detail}"
+    return f"{prefix} (HTTP {resp.status_code})."
+
+
+def looks_headless() -> bool:
+    """Heuristic: SSH or missing display — don't try to open a browser."""
+    import os
+    import sys
+
+    if os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_TTY"):
+        return True
+    if sys.platform == "linux" and not os.environ.get("DISPLAY") and not os.environ.get("WAYLAND_DISPLAY"):
+        return True
+    return False
+
+
+def run_browser_login(
+    *,
+    open_browser: bool = True,
+    timeout: int = LOGIN_TIMEOUT_SECONDS,
+    on_status: Callable[[str], None] | None = None,
+) -> OAuthSession:
+    """Run the interactive authorization-code login and return tokens + client."""
+    metadata = fetch_metadata()
+    result: dict[str, str | None] = {}
+    event = threading.Event()
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+            return
+
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urllib.parse.urlparse(self.path)
+            if parsed.path != "/callback":
+                self.send_error(404)
+                return
+            qs = urllib.parse.parse_qs(parsed.query)
+            result["code"] = (qs.get("code") or [None])[0]
+            result["state"] = (qs.get("state") or [None])[0]
+            result["error"] = (qs.get("error") or [None])[0]
+            result["error_description"] = (qs.get("error_description") or [None])[0]
+            ok = bool(result.get("code")) and not result.get("error")
+            body = _callback_html(success=ok)
+            self.send_response(200 if ok else 400)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            event.set()
+
+    httpd = HTTPServer(("127.0.0.1", 0), Handler)
+    thread: threading.Thread | None = None
+    try:
+        port = httpd.server_address[1]
+        redirect_uri = f"http://127.0.0.1:{port}/callback"
+        registered = register_client(metadata, redirect_uri)
+
+        verifier, challenge = generate_pkce()
+        state = secrets.token_urlsafe(32)
+        authorize_url = build_authorize_url(
+            metadata, registered, state=state, code_challenge=challenge
+        )
+
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+
+        if on_status:
+            on_status(authorize_url)
+        if open_browser:
+            webbrowser.open(authorize_url, new=1, autoraise=True)
+        if not event.wait(timeout):
+            raise OAuthError(
+                f"Timed out after {timeout}s waiting for browser authorization. "
+                "Open the login URL printed above, or use: tvly login --api-key tvly-YOUR_KEY"
+            )
+    finally:
+        if thread is not None:
+            httpd.shutdown()
+            thread.join(timeout=2)
+        httpd.server_close()
+
+    if result.get("error"):
+        desc = result.get("error_description") or result["error"]
+        raise OAuthError(f"Authorization was denied: {desc}")
+    if result.get("state") != state:
+        raise OAuthError("OAuth state mismatch; aborting to prevent CSRF.")
+    code = result.get("code")
+    if not code:
+        raise OAuthError("Authorization callback did not include a code.")
+
+    tokens = exchange_code(metadata, registered, code=code, code_verifier=verifier)
+    return OAuthSession(tokens=tokens, client=registered)
+
+
+def _callback_html(*, success: bool) -> bytes:
+    if success:
+        message = "You're signed in. You can close this tab and return to the terminal."
+        color = "#9BC0AE"
+        title = "Tavily CLI"
+    else:
+        message = "Sign-in didn't complete. Return to the terminal for details."
+        color = "#FAA2FB"
+        title = "Tavily CLI"
+    html = f"""<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><title>{title}</title></head>
+<body style="font-family: system-ui, sans-serif; background:#111; color:#eee;
+             display:flex; min-height:100vh; align-items:center; justify-content:center;">
+  <div style="max-width:32rem; text-align:center;">
+    <p style="color:{color}; font-size:1.25rem; font-weight:600;">tavily</p>
+    <p>{message}</p>
+  </div>
+</body></html>"""
+    return html.encode("utf-8")

--- a/tavily_cli/oauth.py
+++ b/tavily_cli/oauth.py
@@ -140,6 +140,20 @@ def fetch_metadata(client: httpx.Client | None = None) -> OAuthMetadata:
             http.close()
 
 
+def _json_object_response(response: httpx.Response, *, operation: str) -> dict:
+    """Parse a successful OAuth response as a JSON object."""
+    try:
+        data = response.json()
+    except (ValueError, UnicodeDecodeError) as e:
+        raise OAuthError(f"{operation} returned invalid JSON (HTTP {response.status_code}).") from e
+    if not isinstance(data, dict):
+        raise OAuthError(
+            f"{operation} returned an invalid response "
+            f"(HTTP {response.status_code}; expected a JSON object)."
+        )
+    return data
+
+
 def register_client(
     metadata: OAuthMetadata,
     redirect_uri: str,
@@ -162,7 +176,7 @@ def register_client(
         resp = http.post(metadata.registration_endpoint, json=payload)
         if resp.status_code >= 400:
             raise OAuthError(_http_error("Client registration failed", resp))
-        data = resp.json()
+        data = _json_object_response(resp, operation="OAuth client registration")
         client_id = data.get("client_id")
         if not isinstance(client_id, str) or not client_id:
             raise OAuthError("OAuth registration did not return a client_id.")
@@ -173,9 +187,11 @@ def register_client(
                 f"token_endpoint_auth_method {method!r}."
             )
         secret = data.get("client_secret")
-        if method in ("client_secret_post", "client_secret_basic") and not secret:
+        if method in ("client_secret_post", "client_secret_basic") and (
+            not isinstance(secret, str) or not secret
+        ):
             raise OAuthError(
-                f"Authorization server registered the CLI for {method!r} but issued no client_secret."
+                f"Authorization server registered the CLI for {method!r} but issued no valid client_secret."
             )
         return RegisteredClient(
             client_id=client_id,
@@ -322,10 +338,10 @@ def _request_tokens(
         resp = http.post(token_endpoint, data=body, auth=basic)
         if resp.status_code >= 400:
             raise OAuthError(_http_error("Token request failed", resp))
-        data = resp.json()
+        data = _json_object_response(resp, operation="OAuth token endpoint")
         access = data.get("access_token")
         if not isinstance(access, str) or not access:
-            raise OAuthError("OAuth token response did not include an access_token.")
+            raise OAuthError("OAuth token response did not include a valid access_token.")
         refresh = data.get("refresh_token")
         return OAuthTokens(
             access_token=access,

--- a/tavily_cli/oauth.py
+++ b/tavily_cli/oauth.py
@@ -104,6 +104,19 @@ def token_is_expired(expires_at: object, *, now: float | None = None) -> bool:
     return (now if now is not None else time.time()) >= expires_at
 
 
+def _validated_https_url(value: str, *, field: str) -> str:
+    parsed = urllib.parse.urlparse(value)
+    if (
+        parsed.scheme != "https"
+        or not parsed.netloc
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.fragment
+    ):
+        raise OAuthError(f"OAuth discovery returned an invalid {field}; expected a secure HTTPS URL.")
+    return value
+
+
 def fetch_metadata(client: httpx.Client | None = None) -> OAuthMetadata:
     """Discover AS + resource metadata, with static fallbacks if discovery fails."""
     http = client or httpx.Client(timeout=HTTP_TIMEOUT)
@@ -115,7 +128,17 @@ def fetch_metadata(client: httpx.Client | None = None) -> OAuthMetadata:
             resp.raise_for_status()
             discovered = resp.json()
             if isinstance(discovered, dict):
-                data.update({k: v for k, v in discovered.items() if isinstance(v, str)})
+                if discovered.get("issuer") != MCP_ISSUER:
+                    raise OAuthError("OAuth discovery issuer does not match the configured Tavily issuer.")
+                for field in (
+                    "authorization_endpoint",
+                    "token_endpoint",
+                    "registration_endpoint",
+                    "revocation_endpoint",
+                ):
+                    value = discovered.get(field)
+                    if isinstance(value, str):
+                        data[field] = _validated_https_url(value, field=field)
         except (httpx.HTTPError, json.JSONDecodeError, ValueError):
             pass
 
@@ -125,7 +148,10 @@ def fetch_metadata(client: httpx.Client | None = None) -> OAuthMetadata:
             if resp.is_success:
                 prm = resp.json()
                 if isinstance(prm, dict) and isinstance(prm.get("resource"), str):
-                    resource = prm["resource"]
+                    discovered_resource = _validated_https_url(prm["resource"], field="resource")
+                    if discovered_resource != MCP_RESOURCE:
+                        raise OAuthError("OAuth protected-resource metadata does not match the Tavily MCP resource.")
+                    resource = discovered_resource
         except (httpx.HTTPError, json.JSONDecodeError, ValueError):
             pass
 
@@ -134,11 +160,17 @@ def fetch_metadata(client: httpx.Client | None = None) -> OAuthMetadata:
         token = data.get("token_endpoint")
         if not registration or not authorization or not token:
             raise OAuthError("OAuth discovery did not return authorization, token, and registration endpoints.")
+        registration = _validated_https_url(registration, field="registration_endpoint")
+        authorization = _validated_https_url(authorization, field="authorization_endpoint")
+        token = _validated_https_url(token, field="token_endpoint")
+        revocation = data.get("revocation_endpoint")
+        if revocation is not None:
+            revocation = _validated_https_url(revocation, field="revocation_endpoint")
         return OAuthMetadata(
             authorization_endpoint=authorization,
             token_endpoint=token,
             registration_endpoint=registration,
-            revocation_endpoint=data.get("revocation_endpoint"),
+            revocation_endpoint=revocation,
             resource=resource,
         )
     finally:

--- a/tavily_cli/output.py
+++ b/tavily_cli/output.py
@@ -11,21 +11,18 @@ and rendered via ``Text``/validated links rather than markup-bearing f-strings.
 from __future__ import annotations
 
 import json
-import sys
 from typing import Any
 from urllib.parse import urlparse
 
 import click
 from rich.console import Console
 from rich.markdown import Markdown
-from rich.panel import Panel
 from rich.rule import Rule
 from rich.table import Table
 from rich.text import Text
 from rich.tree import Tree
 
 from tavily_cli.common import sanitize_control
-
 
 console = Console()
 err_console = Console(stderr=True)
@@ -130,7 +127,7 @@ def print_search_results(data: dict, *, json_mode: bool, output_file: str | None
 
     if answer:
         console.print()
-        console.print(f"  [#5CD9E6 bold]Answer[/#5CD9E6 bold]")
+        console.print("  [#5CD9E6 bold]Answer[/#5CD9E6 bold]")
         console.print()
         console.print(Markdown(sanitize_control(answer)), width=min(console.width, 100))
         console.print()
@@ -350,7 +347,7 @@ def print_research_result(data: dict, *, json_mode: bool, output_file: str | Non
     # Render the research report as markdown
     if content:
         console.print()
-        console.print(f"  [#5CD9E6 bold]Research Report[/#5CD9E6 bold]")
+        console.print("  [#5CD9E6 bold]Research Report[/#5CD9E6 bold]")
         console.print()
         console.print(Markdown(sanitize_control(content)), width=min(console.width, 100))
 

--- a/tavily_cli/repl.py
+++ b/tavily_cli/repl.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import os
 import readline  # noqa: F401 — enables arrow-key history in input()
 import shlex
-import sys
 
 import click
 from rich.console import Console
@@ -13,9 +11,10 @@ from rich.rule import Rule
 from rich.text import Text
 
 from tavily_cli import __version__
+from tavily_cli.common import handle_oauth_refresh_error
 from tavily_cli.config import get_api_key
+from tavily_cli.oauth import OAuthError
 from tavily_cli.theme import LOGO
-
 
 err_console = Console(stderr=True)
 
@@ -25,7 +24,10 @@ _REPL_COMMANDS = {"search", "extract", "crawl", "map", "research", "login", "log
 
 def _print_banner() -> None:
     """Print the branded welcome banner inside the REPL."""
-    key = get_api_key()
+    try:
+        key = get_api_key()
+    except OAuthError as e:
+        handle_oauth_refresh_error(e, False)
 
     err_console.print(LOGO)
     err_console.print(f"  [dim]v{__version__}[/dim]")
@@ -36,9 +38,9 @@ def _print_banner() -> None:
         source = _auth_source(key)
         err_console.print(f"  [#9BC0AE]>[/#9BC0AE] Authenticated via {source}")
     else:
-        err_console.print(f"  [#FAA2FB]>[/#FAA2FB] Not authenticated")
-        err_console.print(f"    [dim]search and extract work without a key (with a rate-limit cap).[/dim]")
-        err_console.print(f"    Type [#9BC0AE]login[/#9BC0AE] to authenticate and remove the cap.")
+        err_console.print("  [#FAA2FB]>[/#FAA2FB] Not authenticated")
+        err_console.print("    [dim]search and extract work without a key (with a rate-limit cap).[/dim]")
+        err_console.print("    Type [#9BC0AE]login[/#9BC0AE] to authenticate and remove the cap.")
 
     err_console.print()
 

--- a/tavily_cli/theme.py
+++ b/tavily_cli/theme.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Generator
 
 from rich.console import Console
-from rich.status import Status
 
 # Brand colors — from tavily.com
 AQUA = "#5CD9E6"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,189 @@
+"""Tests for one-shot CLI and agent skill setup."""
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from tavily_cli.cli import cli
+from tavily_cli.commands import init as init_module
+from tavily_cli.init_skills import (
+    CORE_SKILLS,
+    SkillsInstallResult,
+    detect_agents,
+    install_skills,
+    verify_skills,
+)
+
+
+def _skills_archive(*, changed_skill: str | None = None, symlink: bool = False) -> bytes:
+    payload = io.BytesIO()
+    with tarfile.open(fileobj=payload, mode="w:gz") as archive:
+        for skill_name in CORE_SKILLS:
+            content = f"---\nname: {skill_name}\n---\n"
+            if skill_name == changed_skill:
+                content += "updated\n"
+            _add_file(archive, f"skills-main/skills/{skill_name}/SKILL.md", content.encode())
+        _add_file(
+            archive,
+            "skills-main/skills/tavily-cli/scripts/check.sh",
+            b"#!/bin/sh\nexit 99\n",
+            mode=0o755,
+        )
+        if symlink:
+            member = tarfile.TarInfo("skills-main/skills/tavily-cli/references/unsafe")
+            member.type = tarfile.SYMTYPE
+            member.linkname = "/etc/passwd"
+            archive.addfile(member)
+    return payload.getvalue()
+
+
+def _add_file(archive: tarfile.TarFile, name: str, content: bytes, *, mode: int = 0o644) -> None:
+    member = tarfile.TarInfo(name)
+    member.size = len(content)
+    member.mode = mode
+    archive.addfile(member, io.BytesIO(content))
+
+
+def test_detect_agents_only_returns_existing_markers(tmp_path: Path) -> None:
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".config" / "opencode").mkdir(parents=True)
+
+    assert detect_agents(tmp_path) == ("codex",)
+
+
+def test_skill_install_honors_custom_agent_directories(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    default_home = tmp_path / "home"
+    codex_home = tmp_path / "custom-codex"
+    claude_home = tmp_path / "custom-claude"
+    default_home.mkdir()
+    codex_home.mkdir()
+    claude_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: default_home)
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_home))
+
+    assert detect_agents() == ("claude-code", "codex")
+
+    install_skills(("claude-code", "codex"), archive=_skills_archive())
+
+    assert verify_skills(("claude-code", "codex"))
+    assert (claude_home / "skills" / "tavily-search" / "SKILL.md").is_file()
+    assert (codex_home / "skills" / "tavily-search" / "SKILL.md").is_file()
+    assert not (default_home / ".claude").exists()
+    assert not (default_home / ".codex").exists()
+
+
+def test_skill_install_is_complete_and_idempotent(tmp_path: Path) -> None:
+    archive = _skills_archive()
+
+    first = install_skills(("codex",), home=tmp_path, archive=archive)
+
+    assert first.installed == len(CORE_SKILLS)
+    assert first.updated == 0
+    assert first.linked == len(CORE_SKILLS)
+    assert first.restart_required
+    assert verify_skills(("codex",), home=tmp_path)
+    script = tmp_path / ".agents" / "skills" / "tavily-cli" / "scripts" / "check.sh"
+    assert script.read_text() == "#!/bin/sh\nexit 99\n"
+    assert script.stat().st_mode & 0o111
+
+    second = install_skills(("codex",), home=tmp_path, archive=archive)
+
+    assert second.installed == 0
+    assert second.updated == 0
+    assert second.unchanged == len(CORE_SKILLS)
+    assert second.linked == 0
+    assert not second.restart_required
+
+
+def test_skill_install_without_agent_uses_shared_directory(tmp_path: Path) -> None:
+    result = install_skills((), home=tmp_path, archive=_skills_archive())
+
+    assert result.agents == ()
+    assert result.installed == len(CORE_SKILLS)
+    assert result.linked == 0
+    assert verify_skills((), home=tmp_path)
+
+
+def test_skill_install_updates_only_changed_core_skill(tmp_path: Path) -> None:
+    install_skills(("claude-code",), home=tmp_path, archive=_skills_archive())
+
+    updated = install_skills(
+        ("claude-code",),
+        home=tmp_path,
+        archive=_skills_archive(changed_skill="tavily-search"),
+    )
+
+    assert updated.updated == 1
+    assert updated.unchanged == len(CORE_SKILLS) - 1
+    assert "updated" in (tmp_path / ".agents" / "skills" / "tavily-search" / "SKILL.md").read_text()
+
+
+def test_skill_install_rejects_archive_links(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unsupported archive entry"):
+        install_skills((), home=tmp_path, archive=_skills_archive(symlink=True))
+
+
+def test_skill_install_checks_conflicts_before_writing(tmp_path: Path) -> None:
+    conflict = tmp_path / ".agents" / "skills" / CORE_SKILLS[-1]
+    conflict.parent.mkdir(parents=True)
+    conflict.write_text("owned by the user")
+
+    with pytest.raises(ValueError, match="non-directory path"):
+        install_skills((), home=tmp_path, archive=_skills_archive())
+
+    assert not (tmp_path / ".agents" / "skills" / CORE_SKILLS[0]).exists()
+
+
+def test_init_json_reuses_environment_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(init_module, "detect_agents", lambda: ("codex",))
+    monkeypatch.setattr(
+        init_module,
+        "install_skills",
+        lambda agents: SkillsInstallResult(agents, 8, 0, 0, 8, True),
+    )
+    monkeypatch.setattr(init_module, "verify_skills", lambda agents: True)
+    monkeypatch.setattr(init_module, "_verify_cli", lambda: True)
+    monkeypatch.setattr(init_module, "_verify_live_search", lambda: True)
+
+    result = CliRunner().invoke(cli, ["init", "--json"], env={"TAVILY_API_KEY": "tvly-test"})
+
+    assert result.exit_code == 0
+    output = json.loads(result.stdout)
+    assert output["ok"] is True
+    assert output["auth"] == {"authenticated": True, "method": "env"}
+    assert output["skills"]["agents"] == ["codex"]
+    assert output["verification"]["live_search"] is True
+
+
+def test_init_noninteractive_auth_failure_is_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tavily_cli import config
+
+    monkeypatch.setattr(config, "get_api_key", lambda: None)
+    result = CliRunner().invoke(cli, ["init", "--skip-skills", "--json"])
+
+    assert result.exit_code == 3
+    output = json.loads(result.stdout)
+    assert output["ok"] is False
+    assert output["error"]["stage"] == "auth"
+    assert output["skills"]["skipped"] is True
+
+
+def test_init_live_search_failure_exits_four(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(init_module, "_verify_cli", lambda: True)
+    monkeypatch.setattr(init_module, "_verify_live_search", lambda: False)
+
+    result = CliRunner().invoke(cli, ["init", "--skip-auth", "--skip-skills", "--json"])
+
+    assert result.exit_code == 4
+    output = json.loads(result.stdout)
+    assert output["error"]["stage"] == "live_search"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,20 +2,24 @@
 
 from __future__ import annotations
 
+import hashlib
 import io
 import json
 import tarfile
 from pathlib import Path
 
+import httpx
 import pytest
 from click.testing import CliRunner
 
+from tavily_cli import init_skills as init_skills_module
 from tavily_cli.cli import cli
 from tavily_cli.commands import init as init_module
 from tavily_cli.init_skills import (
     CORE_SKILLS,
     SkillsInstallResult,
     detect_agents,
+    download_skills_archive,
     install_skills,
     verify_skills,
 )
@@ -48,6 +52,27 @@ def _add_file(archive: tarfile.TarFile, name: str, content: bytes, *, mode: int 
     member.size = len(content)
     member.mode = mode
     archive.addfile(member, io.BytesIO(content))
+
+
+def test_download_skills_archive_verifies_checksum(monkeypatch: pytest.MonkeyPatch) -> None:
+    archive = _skills_archive()
+    monkeypatch.setattr(
+        init_skills_module,
+        "SKILLS_ARCHIVE_SHA256",
+        hashlib.sha256(archive).hexdigest(),
+    )
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, content=archive, request=request))
+
+    with httpx.Client(transport=transport) as client:
+        assert download_skills_archive(client=client) == archive
+
+
+def test_download_skills_archive_rejects_checksum_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(init_skills_module, "SKILLS_ARCHIVE_SHA256", "0" * 64)
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, content=b"tampered", request=request))
+
+    with httpx.Client(transport=transport) as client, pytest.raises(ValueError, match="integrity verification"):
+        download_skills_archive(client=client)
 
 
 def test_detect_agents_only_returns_existing_markers(tmp_path: Path) -> None:
@@ -94,7 +119,7 @@ def test_skill_install_is_complete_and_idempotent(tmp_path: Path) -> None:
     assert verify_skills(("codex",), home=tmp_path)
     script = tmp_path / ".agents" / "skills" / "tavily-cli" / "scripts" / "check.sh"
     assert script.read_text() == "#!/bin/sh\nexit 99\n"
-    assert script.stat().st_mode & 0o111
+    assert script.stat().st_mode & 0o111 == 0
 
     second = install_skills(("codex",), home=tmp_path, archive=archive)
 
@@ -179,6 +204,9 @@ def test_init_noninteractive_auth_failure_is_json(monkeypatch: pytest.MonkeyPatc
 
 
 def test_init_live_search_failure_exits_four(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tavily_cli import config
+
+    monkeypatch.setattr(config, "get_api_key", lambda: None)
     monkeypatch.setattr(init_module, "_verify_cli", lambda: True)
     monkeypatch.setattr(init_module, "_verify_live_search", lambda: False)
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -104,6 +104,57 @@ def test_register_client_rejects_http_errors() -> None:
         register_client(metadata, "http://127.0.0.1:1/callback", client=http)
 
 
+@pytest.mark.parametrize(
+    ("response_kind", "expected_error"),
+    [
+        ("html", "OAuth client registration returned invalid JSON"),
+        ("list", "expected a JSON object"),
+        ("missing_client_id", "did not return a client_id"),
+    ],
+)
+def test_register_client_normalizes_malformed_success_responses(
+    response_kind: str,
+    expected_error: str,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if response_kind == "html":
+            return httpx.Response(200, text="<html>temporary proxy error</html>")
+        if response_kind == "list":
+            return httpx.Response(200, json=["not", "an", "object"])
+        return httpx.Response(200, json={})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    metadata = OAuthMetadata(
+        authorization_endpoint="https://mcp.tavily.com/authorize",
+        token_endpoint="https://mcp.tavily.com/token",
+        registration_endpoint="https://mcp.tavily.com/register",
+        revocation_endpoint=None,
+    )
+
+    with pytest.raises(OAuthError, match=expected_error):
+        register_client(metadata, "http://127.0.0.1:1/callback", client=http)
+
+
+def test_register_client_rejects_invalid_confidential_client_secret() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={
+            "client_id": "cid",
+            "client_secret": 123,
+            "token_endpoint_auth_method": "client_secret_post",
+        })
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    metadata = OAuthMetadata(
+        authorization_endpoint="https://mcp.tavily.com/authorize",
+        token_endpoint="https://mcp.tavily.com/token",
+        registration_endpoint="https://mcp.tavily.com/register",
+        revocation_endpoint=None,
+    )
+
+    with pytest.raises(OAuthError, match="issued no valid client_secret"):
+        register_client(metadata, "http://127.0.0.1:1/callback", client=http)
+
+
 def test_fetch_metadata_uses_discovery() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         url = str(request.url)
@@ -150,6 +201,45 @@ def test_refresh_tokens_keeps_refresh_if_omitted() -> None:
     tokens = refresh_tokens(metadata, client, "old-refresh", client=http)
     assert tokens.access_token == "new-access"
     assert tokens.refresh_token == "old-refresh"
+
+
+@pytest.mark.parametrize(
+    ("response_kind", "expected_error"),
+    [
+        ("html", "OAuth token endpoint returned invalid JSON"),
+        ("list", "expected a JSON object"),
+        ("missing_access_token", "did not include a valid access_token"),
+    ],
+)
+def test_token_request_normalizes_malformed_success_responses(
+    response_kind: str,
+    expected_error: str,
+) -> None:
+    from tavily_cli.oauth import refresh_tokens
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if response_kind == "html":
+            return httpx.Response(200, text="<html>temporary proxy error</html>")
+        if response_kind == "list":
+            return httpx.Response(200, json=["not", "an", "object"])
+        return httpx.Response(200, json={})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    metadata = OAuthMetadata(
+        authorization_endpoint="https://mcp.tavily.com/authorize",
+        token_endpoint="https://mcp.tavily.com/token",
+        registration_endpoint="https://mcp.tavily.com/register",
+        revocation_endpoint=None,
+    )
+    client = RegisteredClient(
+        client_id="cid",
+        client_secret=None,
+        token_endpoint_auth_method="none",
+        redirect_uri="http://127.0.0.1:1/callback",
+    )
+
+    with pytest.raises(OAuthError, match=expected_error):
+        refresh_tokens(metadata, client, "old-refresh", client=http)
 
 
 def test_revoke_public_client_uses_standard_request_first() -> None:

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,0 +1,183 @@
+"""Tests for native MCP OAuth helpers and credential storage."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from pathlib import Path
+
+import httpx
+import pytest
+
+from tavily_cli.oauth import (
+    OAuthError,
+    OAuthMetadata,
+    RegisteredClient,
+    build_authorize_url,
+    expires_at_from_now,
+    fetch_metadata,
+    generate_pkce,
+    register_client,
+    token_is_expired,
+)
+
+
+def test_pkce_is_s256_and_unpadded() -> None:
+    verifier, challenge = generate_pkce()
+    assert 43 <= len(verifier) <= 128
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    expected = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+    assert challenge == expected
+    assert "=" not in challenge
+
+
+def test_token_expiry_skew() -> None:
+    now = 1_000_000.0
+    expires_at = expires_at_from_now(3600, now=now)
+    assert expires_at == now + 3600 - 60
+    assert not token_is_expired(expires_at, now=now)
+    assert token_is_expired(expires_at, now=expires_at)
+    assert token_is_expired(None)
+
+
+def test_authorize_url_includes_pkce_and_resource() -> None:
+    metadata = OAuthMetadata(
+        authorization_endpoint="https://mcp.tavily.com/authorize",
+        token_endpoint="https://mcp.tavily.com/token",
+        registration_endpoint="https://mcp.tavily.com/register",
+        revocation_endpoint="https://mcp.tavily.com/revoke",
+        resource="https://mcp.tavily.com/mcp",
+    )
+    client = RegisteredClient(
+        client_id="cli-1",
+        client_secret=None,
+        token_endpoint_auth_method="none",
+        redirect_uri="http://127.0.0.1:9999/callback",
+    )
+    url = build_authorize_url(metadata, client, state="st", code_challenge="ch")
+    assert url.startswith("https://mcp.tavily.com/authorize?")
+    assert "client_id=cli-1" in url
+    assert "code_challenge=ch" in url
+    assert "code_challenge_method=S256" in url
+    assert "state=st" in url
+    assert "resource=https%3A%2F%2Fmcp.tavily.com%2Fmcp" in url
+    assert "scope=openid+offline_access" in url or "scope=openid%20offline_access" in url
+
+
+def test_register_client_public_pkce() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url) == "https://mcp.tavily.com/register"
+        body = request.read()
+        assert b"token_endpoint_auth_method" in body
+        assert b"Tavily CLI" in body
+        return httpx.Response(201, json={"client_id": "cid-1", "token_endpoint_auth_method": "none"})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    metadata = OAuthMetadata(
+        authorization_endpoint="https://mcp.tavily.com/authorize",
+        token_endpoint="https://mcp.tavily.com/token",
+        registration_endpoint="https://mcp.tavily.com/register",
+        revocation_endpoint=None,
+    )
+    registered = register_client(metadata, "http://127.0.0.1:1/callback", client=http)
+    assert registered.client_id == "cid-1"
+    assert registered.client_secret is None
+    assert registered.token_endpoint_auth_method == "none"
+
+
+def test_register_client_rejects_http_errors() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, text="invalid redirect")
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    metadata = OAuthMetadata(
+        authorization_endpoint="https://mcp.tavily.com/authorize",
+        token_endpoint="https://mcp.tavily.com/token",
+        registration_endpoint="https://mcp.tavily.com/register",
+        revocation_endpoint=None,
+    )
+    with pytest.raises(OAuthError, match="Client registration failed"):
+        register_client(metadata, "http://127.0.0.1:1/callback", client=http)
+
+
+def test_fetch_metadata_uses_discovery() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if url.endswith("oauth-authorization-server"):
+            return httpx.Response(200, json={
+                "authorization_endpoint": "https://mcp.tavily.com/authorize",
+                "token_endpoint": "https://mcp.tavily.com/token",
+                "registration_endpoint": "https://mcp.tavily.com/register",
+                "revocation_endpoint": "https://mcp.tavily.com/revoke",
+            })
+        if url.endswith("oauth-protected-resource/mcp"):
+            return httpx.Response(200, json={"resource": "https://mcp.tavily.com/mcp"})
+        return httpx.Response(404)
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    meta = fetch_metadata(http)
+    assert meta.authorization_endpoint == "https://mcp.tavily.com/authorize"
+    assert meta.resource == "https://mcp.tavily.com/mcp"
+
+
+def test_refresh_tokens_keeps_refresh_if_omitted() -> None:
+    from tavily_cli.oauth import refresh_tokens
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert b"grant_type=refresh_token" in request.read()
+        return httpx.Response(200, json={
+            "access_token": "new-access",
+            "expires_in": 3600,
+        })
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    metadata = OAuthMetadata(
+        authorization_endpoint="https://mcp.tavily.com/authorize",
+        token_endpoint="https://mcp.tavily.com/token",
+        registration_endpoint="https://mcp.tavily.com/register",
+        revocation_endpoint=None,
+    )
+    client = RegisteredClient(
+        client_id="cid",
+        client_secret=None,
+        token_endpoint_auth_method="none",
+        redirect_uri="http://127.0.0.1:1/callback",
+    )
+    tokens = refresh_tokens(metadata, client, "old-refresh", client=http)
+    assert tokens.access_token == "new-access"
+    assert tokens.refresh_token == "old-refresh"
+
+
+def test_api_key_and_oauth_replace_each_other(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from tavily_cli import config
+    from tavily_cli.oauth import OAuthSession, OAuthTokens
+
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+
+    config.save_api_key("tvly-test-key")
+    assert config.get_api_key() == "tvly-test-key"
+
+    session = OAuthSession(
+        tokens=OAuthTokens(
+            access_token="header.payload.sig",
+            refresh_token="r1",
+            expires_at=expires_at_from_now(3600),
+        ),
+        client=RegisteredClient(
+            client_id="cid",
+            client_secret=None,
+            token_endpoint_auth_method="none",
+            redirect_uri="http://127.0.0.1:1/callback",
+        ),
+    )
+    config.save_oauth_session(session)
+    assert config.has_stored_oauth()
+    assert config.get_api_key() == "header.payload.sig"
+    stored = config._read_config()
+    assert "api_key" not in stored
+
+    config.save_api_key("tvly-other")
+    assert config.get_api_key() == "tvly-other"
+    assert not config.has_stored_oauth()

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -335,6 +335,97 @@ def test_logout_json_reports_partial_revocation_failure(monkeypatch: pytest.Monk
     }
 
 
+@pytest.mark.parametrize(
+    ("arguments", "headless"),
+    [
+        (["--json", "--no-browser"], False),
+        (["--json"], True),
+    ],
+)
+def test_json_headless_login_emits_authorization_url_on_stderr(
+    arguments: list[str],
+    headless: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tavily_cli import oauth
+    from tavily_cli.commands import auth
+    from tavily_cli.oauth import OAuthSession, OAuthTokens
+
+    session = OAuthSession(
+        tokens=OAuthTokens(
+            access_token="access-1",
+            refresh_token="refresh-1",
+            expires_at=expires_at_from_now(3600),
+        ),
+        client=RegisteredClient(
+            client_id="cid",
+            client_secret=None,
+            token_endpoint_auth_method="none",
+            redirect_uri="http://127.0.0.1:9999/callback",
+        ),
+    )
+
+    monkeypatch.setattr(oauth, "looks_headless", lambda: headless)
+    monkeypatch.setattr(auth, "save_oauth_session", lambda value: None)
+
+    def complete_login(*, open_browser: bool, on_status: object) -> OAuthSession:
+        assert open_browser is False
+        assert callable(on_status)
+        on_status("https://mcp.tavily.com/authorize?client_id=cid")
+        return session
+
+    monkeypatch.setattr(oauth, "run_browser_login", complete_login)
+
+    result = CliRunner().invoke(auth.login, arguments)
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {
+        "authenticated": True,
+        "method": "oauth",
+        "detail": f"Token stored in {auth.CONFIG_FILE}",
+    }
+    assert json.loads(result.stderr) == {
+        "event": "authorization_required",
+        "authorization_url": "https://mcp.tavily.com/authorize?client_id=cid",
+    }
+
+
+def test_json_browser_login_keeps_stderr_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tavily_cli import oauth
+    from tavily_cli.commands import auth
+    from tavily_cli.oauth import OAuthSession, OAuthTokens
+
+    session = OAuthSession(
+        tokens=OAuthTokens(
+            access_token="access-1",
+            refresh_token="refresh-1",
+            expires_at=expires_at_from_now(3600),
+        ),
+        client=RegisteredClient(
+            client_id="cid",
+            client_secret=None,
+            token_endpoint_auth_method="none",
+            redirect_uri="http://127.0.0.1:9999/callback",
+        ),
+    )
+
+    monkeypatch.setattr(oauth, "looks_headless", lambda: False)
+    monkeypatch.setattr(auth, "save_oauth_session", lambda value: None)
+
+    def complete_login(*, open_browser: bool, on_status: object) -> OAuthSession:
+        assert open_browser is True
+        assert on_status is None
+        return session
+
+    monkeypatch.setattr(oauth, "run_browser_login", complete_login)
+
+    result = CliRunner().invoke(auth.login, ["--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["authenticated"] is True
+    assert result.stderr == ""
+
+
 def test_api_key_and_oauth_replace_each_other(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from tavily_cli import config
     from tavily_cli.oauth import OAuthSession, OAuthTokens

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -421,15 +421,82 @@ def test_logout_json_reports_partial_revocation_failure(monkeypatch: pytest.Monk
             revocation_error="Token revocation failed (HTTP 500).",
         ),
     )
+    monkeypatch.setattr(auth, "get_api_key", lambda: None)
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
 
     result = CliRunner().invoke(auth.logout, ["--json"])
 
     assert result.exit_code == 3
     assert json.loads(result.output) == {
         "authenticated": False,
+        "method": None,
+        "source": None,
         "local_credentials_cleared": True,
+        "environment_credential_present": False,
         "server_revoked": False,
         "error": "Token revocation failed (HTTP 500).",
+    }
+
+
+def test_logout_json_reports_remaining_environment_credential(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tavily_cli.commands import auth
+    from tavily_cli.config import ClearCredentialsResult
+
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-environment-secret")
+    monkeypatch.setattr(
+        auth,
+        "clear_credentials",
+        lambda: ClearCredentialsResult(
+            local_credentials_cleared=True,
+            server_revoked=None,
+        ),
+    )
+
+    logout_result = CliRunner().invoke(auth.logout, ["--json"])
+    auth_result = CliRunner().invoke(auth.auth_status, ["--json"])
+
+    assert logout_result.exit_code == 0
+    logout_payload = json.loads(logout_result.output)
+    assert logout_payload == {
+        "authenticated": True,
+        "method": "env",
+        "source": "TAVILY_API_KEY environment variable",
+        "local_credentials_cleared": True,
+        "environment_credential_present": True,
+        "warning": auth._ENV_CREDENTIAL_WARNING,
+    }
+    assert "tvly-environment-secret" not in logout_result.output
+    assert json.loads(auth_result.output) == {
+        "authenticated": True,
+        "method": "env",
+        "source": "TAVILY_API_KEY environment variable",
+    }
+
+
+def test_logout_json_reports_unauthenticated_after_cleanup(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tavily_cli.commands import auth
+    from tavily_cli.config import ClearCredentialsResult
+
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    monkeypatch.setattr(auth, "get_api_key", lambda: None)
+    monkeypatch.setattr(
+        auth,
+        "clear_credentials",
+        lambda: ClearCredentialsResult(
+            local_credentials_cleared=True,
+            server_revoked=None,
+        ),
+    )
+
+    result = CliRunner().invoke(auth.logout, ["--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "authenticated": False,
+        "method": None,
+        "source": None,
+        "local_credentials_cleared": True,
+        "environment_credential_present": False,
     }
 
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import subprocess
+import sys
+import threading
+import time
 from pathlib import Path
 from urllib.parse import parse_qs
 
@@ -168,6 +172,7 @@ def test_fetch_metadata_uses_discovery() -> None:
         url = str(request.url)
         if url.endswith("oauth-authorization-server"):
             return httpx.Response(200, json={
+                "issuer": "https://mcp.tavily.com/",
                 "authorization_endpoint": "https://mcp.tavily.com/authorize",
                 "token_endpoint": "https://mcp.tavily.com/token",
                 "registration_endpoint": "https://mcp.tavily.com/register",
@@ -181,6 +186,55 @@ def test_fetch_metadata_uses_discovery() -> None:
     meta = fetch_metadata(http)
     assert meta.authorization_endpoint == "https://mcp.tavily.com/authorize"
     assert meta.resource == "https://mcp.tavily.com/mcp"
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected_error"),
+    [
+        ("issuer", "https://attacker.example/", "issuer does not match"),
+        ("token_endpoint", "http://mcp.tavily.com/token", "invalid token_endpoint"),
+        ("registration_endpoint", "https://user:pass@mcp.tavily.com/register", "invalid registration_endpoint"),
+    ],
+)
+def test_fetch_metadata_rejects_untrusted_authorization_metadata(
+    field: str,
+    value: str,
+    expected_error: str,
+) -> None:
+    metadata = {
+        "issuer": "https://mcp.tavily.com/",
+        "authorization_endpoint": "https://mcp.tavily.com/authorize",
+        "token_endpoint": "https://mcp.tavily.com/token",
+        "registration_endpoint": "https://mcp.tavily.com/register",
+        "revocation_endpoint": "https://mcp.tavily.com/revoke",
+    }
+    metadata[field] = value
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url).endswith("oauth-authorization-server"):
+            return httpx.Response(200, json=metadata)
+        return httpx.Response(200, json={"resource": "https://mcp.tavily.com/mcp"})
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http, pytest.raises(OAuthError, match=expected_error):
+        fetch_metadata(http)
+
+
+def test_fetch_metadata_rejects_different_protected_resource() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url).endswith("oauth-authorization-server"):
+            return httpx.Response(200, json={
+                "issuer": "https://mcp.tavily.com/",
+                "authorization_endpoint": "https://mcp.tavily.com/authorize",
+                "token_endpoint": "https://mcp.tavily.com/token",
+                "registration_endpoint": "https://mcp.tavily.com/register",
+            })
+        return httpx.Response(200, json={"resource": "https://attacker.example/mcp"})
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http, pytest.raises(
+        OAuthError,
+        match="does not match the Tavily MCP resource",
+    ):
+        fetch_metadata(http)
 
 
 def test_refresh_tokens_keeps_refresh_if_omitted() -> None:
@@ -771,6 +825,177 @@ def test_malformed_expiry_without_refresh_is_invalid() -> None:
     })
 
     assert access_token is None
+
+
+def test_config_write_keeps_previous_file_when_atomic_replace_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tavily_cli import config
+
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
+    config._write_config({"api_key": "tvly-old"})
+
+    monkeypatch.setattr(config.os, "replace", lambda source, target: (_ for _ in ()).throw(OSError("disk busy")))
+
+    with pytest.raises(OSError, match="disk busy"):
+        config._write_config({"api_key": "tvly-new"})
+
+    assert config._read_config() == {"api_key": "tvly-old"}
+    assert not list(tmp_path.glob(".config.json.*.tmp"))
+
+
+def test_parallel_expired_session_refreshes_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tavily_cli import config, oauth
+    from tavily_cli.oauth import OAuthTokens
+
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
+    config._write_config({
+        "oauth": {
+            "access_token": "old-access",
+            "refresh_token": "old-refresh",
+            "expires_at": 0,
+            "client_id": "same-client",
+            "client_secret": None,
+            "token_endpoint_auth_method": "none",
+            "redirect_uri": "http://127.0.0.1:1/callback",
+        }
+    })
+
+    refresh_started = threading.Event()
+    release_refresh = threading.Event()
+    second_started = threading.Event()
+    refresh_calls: list[str] = []
+    results: list[str | None] = []
+    errors: list[Exception] = []
+
+    monkeypatch.setattr(oauth, "fetch_metadata", lambda: object())
+
+    def refresh_once(metadata: object, client: RegisteredClient, refresh_token: str) -> OAuthTokens:
+        refresh_calls.append(refresh_token)
+        refresh_started.set()
+        assert release_refresh.wait(timeout=2)
+        return OAuthTokens(
+            access_token="new-access",
+            refresh_token="new-refresh",
+            expires_at=expires_at_from_now(3600),
+        )
+
+    monkeypatch.setattr(oauth, "refresh_tokens", refresh_once)
+
+    def resolve(*, second: bool = False) -> None:
+        if second:
+            second_started.set()
+        try:
+            results.append(config.get_api_key())
+        except Exception as e:
+            errors.append(e)
+
+    first = threading.Thread(target=resolve)
+    first.start()
+    assert refresh_started.wait(timeout=2)
+    second = threading.Thread(target=resolve, kwargs={"second": True})
+    second.start()
+    assert second_started.wait(timeout=2)
+    release_refresh.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+    assert results == ["new-access", "new-access"]
+    assert refresh_calls == ["old-refresh"]
+    assert config._read_config()["oauth"]["refresh_token"] == "new-refresh"
+
+
+def test_config_lock_serializes_separate_processes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tavily_cli import config
+
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
+    config._write_config({"api_key": "tvly-old"})
+    started = tmp_path / "child-started"
+    child_code = "\n".join((
+        "import sys",
+        "from pathlib import Path",
+        "from tavily_cli import config",
+        "root = Path(sys.argv[1])",
+        "config.CONFIG_DIR = root",
+        "config.CONFIG_FILE = root / 'config.json'",
+        "(root / 'child-started').touch()",
+        "config._write_config({'api_key': 'tvly-new'})",
+    ))
+
+    with config._config_lock():
+        child = subprocess.Popen(
+            [sys.executable, "-c", child_code, str(tmp_path)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        deadline = time.monotonic() + 5
+        while not started.exists() and child.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert started.exists()
+        time.sleep(0.1)
+        assert child.poll() is None
+        assert config._read_config() == {"api_key": "tvly-old"}
+
+    stdout, stderr = child.communicate(timeout=5)
+    assert child.returncode == 0, stdout + stderr
+    assert config._read_config() == {"api_key": "tvly-new"}
+
+
+def test_refresh_failure_is_reported_and_preserves_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tavily_cli import config, oauth
+
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
+    previous = {
+        "access_token": "old-access",
+        "refresh_token": "old-refresh",
+        "expires_at": 0,
+        "client_id": "same-client",
+        "client_secret": None,
+        "token_endpoint_auth_method": "none",
+        "redirect_uri": "http://127.0.0.1:1/callback",
+    }
+    config._write_config({"oauth": previous})
+    monkeypatch.setattr(oauth, "fetch_metadata", lambda: (_ for _ in ()).throw(OAuthError("network down")))
+
+    with pytest.raises(OAuthError, match="Could not refresh.*network down"):
+        config.get_api_key()
+
+    assert config._read_config() == {"oauth": previous}
+
+
+def test_search_json_reports_refresh_failure_without_keyless_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tavily_cli import config
+    from tavily_cli.cli import cli
+
+    monkeypatch.setattr(config, "get_api_key", lambda: (_ for _ in ()).throw(OAuthError("network down")))
+
+    result = CliRunner().invoke(cli, ["search", "query", "--json"])
+
+    assert result.exit_code == 3
+    assert json.loads(result.stdout) == {
+        "error": {
+            "code": "oauth_refresh_failed",
+            "message": "network down",
+        }
+    }
 
 
 def test_api_key_login_json_reports_replacement_revocation_failure(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import json
 from pathlib import Path
+from urllib.parse import parse_qs
 
 import httpx
 import pytest
+from click.testing import CliRunner
 
 from tavily_cli.oauth import (
     OAuthError,
@@ -18,6 +21,7 @@ from tavily_cli.oauth import (
     fetch_metadata,
     generate_pkce,
     register_client,
+    revoke_token,
     token_is_expired,
 )
 
@@ -146,6 +150,189 @@ def test_refresh_tokens_keeps_refresh_if_omitted() -> None:
     tokens = refresh_tokens(metadata, client, "old-refresh", client=http)
     assert tokens.access_token == "new-access"
     assert tokens.refresh_token == "old-refresh"
+
+
+def test_revoke_public_client_uses_standard_request_first() -> None:
+    requests: list[dict[str, list[str]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(parse_qs(request.read().decode(), keep_blank_values=True))
+        return httpx.Response(200)
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    metadata = OAuthMetadata(
+        authorization_endpoint="https://mcp.tavily.com/authorize",
+        token_endpoint="https://mcp.tavily.com/token",
+        registration_endpoint="https://mcp.tavily.com/register",
+        revocation_endpoint="https://mcp.tavily.com/revoke",
+    )
+    client = RegisteredClient(
+        client_id="cid",
+        client_secret=None,
+        token_endpoint_auth_method="none",
+        redirect_uri="http://127.0.0.1:1/callback",
+    )
+
+    revoke_token(metadata, client, "refresh-1", token_type_hint="refresh_token", client=http)
+
+    assert requests == [{
+        "token": ["refresh-1"],
+        "token_type_hint": ["refresh_token"],
+        "client_id": ["cid"],
+    }]
+
+
+def test_revoke_public_client_retries_known_400_with_empty_secret() -> None:
+    requests: list[dict[str, list[str]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = parse_qs(request.read().decode(), keep_blank_values=True)
+        requests.append(body)
+        if len(requests) == 1:
+            return httpx.Response(400, json={"error": "invalid_request"})
+        return httpx.Response(200)
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    metadata = OAuthMetadata(
+        authorization_endpoint="https://mcp.tavily.com/authorize",
+        token_endpoint="https://mcp.tavily.com/token",
+        registration_endpoint="https://mcp.tavily.com/register",
+        revocation_endpoint="https://mcp.tavily.com/revoke",
+    )
+    client = RegisteredClient(
+        client_id="cid",
+        client_secret=None,
+        token_endpoint_auth_method="none",
+        redirect_uri="http://127.0.0.1:1/callback",
+    )
+
+    revoke_token(metadata, client, "refresh-1", token_type_hint="refresh_token", client=http)
+
+    assert "client_secret" not in requests[0]
+    assert requests[1]["client_secret"] == [""]
+    assert requests[1]["client_id"] == ["cid"]
+
+
+def test_revoke_token_raises_after_failed_compatibility_retry() -> None:
+    request_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        request_count += 1
+        return httpx.Response(400, json={"error": "invalid_request"})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    metadata = OAuthMetadata(
+        authorization_endpoint="https://mcp.tavily.com/authorize",
+        token_endpoint="https://mcp.tavily.com/token",
+        registration_endpoint="https://mcp.tavily.com/register",
+        revocation_endpoint="https://mcp.tavily.com/revoke",
+    )
+    client = RegisteredClient(
+        client_id="cid",
+        client_secret=None,
+        token_endpoint_auth_method="none",
+        redirect_uri="http://127.0.0.1:1/callback",
+    )
+
+    with pytest.raises(OAuthError, match=r"Token revocation failed \(HTTP 400\)"):
+        revoke_token(metadata, client, "refresh-1", token_type_hint="refresh_token", client=http)
+    assert request_count == 2
+
+
+def test_stored_oauth_revokes_refresh_before_access(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tavily_cli import config, oauth
+
+    metadata = OAuthMetadata(
+        authorization_endpoint="https://mcp.tavily.com/authorize",
+        token_endpoint="https://mcp.tavily.com/token",
+        registration_endpoint="https://mcp.tavily.com/register",
+        revocation_endpoint="https://mcp.tavily.com/revoke",
+    )
+    calls: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(oauth, "fetch_metadata", lambda: metadata)
+
+    def record_revocation(
+        metadata: OAuthMetadata,
+        client: RegisteredClient,
+        token: str,
+        *,
+        token_type_hint: str,
+    ) -> None:
+        calls.append((token, token_type_hint))
+
+    monkeypatch.setattr(oauth, "revoke_token", record_revocation)
+
+    attempted = config._revoke_stored_oauth({
+        "access_token": "access-1",
+        "refresh_token": "refresh-1",
+        "client_id": "cid",
+        "token_endpoint_auth_method": "none",
+    })
+
+    assert attempted is True
+    assert calls == [
+        ("refresh-1", "refresh_token"),
+        ("access-1", "access_token"),
+    ]
+
+
+def test_clear_credentials_reports_revocation_failure_but_clears_disk(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tavily_cli import config
+
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
+    monkeypatch.setattr(config, "MCP_AUTH_DIR", tmp_path / "mcp-auth")
+    config._write_config({
+        "human_id": "keep-me",
+        "oauth": {
+            "access_token": "access-1",
+            "refresh_token": "refresh-1",
+            "client_id": "cid",
+            "token_endpoint_auth_method": "none",
+        },
+    })
+
+    def fail_revocation(data: dict) -> bool:
+        raise OAuthError("Token revocation failed (HTTP 500).")
+
+    monkeypatch.setattr(config, "_revoke_stored_oauth", fail_revocation)
+
+    result = config.clear_credentials()
+
+    assert result.local_credentials_cleared is True
+    assert result.server_revoked is False
+    assert result.revocation_error == "Token revocation failed (HTTP 500)."
+    assert config._read_config() == {"human_id": "keep-me"}
+
+
+def test_logout_json_reports_partial_revocation_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tavily_cli.commands import auth
+    from tavily_cli.config import ClearCredentialsResult
+
+    monkeypatch.setattr(
+        auth,
+        "clear_credentials",
+        lambda: ClearCredentialsResult(
+            local_credentials_cleared=True,
+            server_revoked=False,
+            revocation_error="Token revocation failed (HTTP 500).",
+        ),
+    )
+
+    result = CliRunner().invoke(auth.logout, ["--json"])
+
+    assert result.exit_code == 3
+    assert json.loads(result.output) == {
+        "authenticated": False,
+        "local_credentials_cleared": True,
+        "server_revoked": False,
+        "error": "Token revocation failed (HTTP 500).",
+    }
 
 
 def test_api_key_and_oauth_replace_each_other(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -426,6 +426,228 @@ def test_json_browser_login_keeps_stderr_empty(monkeypatch: pytest.MonkeyPatch) 
     assert result.stderr == ""
 
 
+def test_save_api_key_keeps_previous_oauth_when_revocation_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tavily_cli import config
+
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
+    previous = {
+        "access_token": "old-access",
+        "refresh_token": "old-refresh",
+        "client_id": "old-client",
+        "token_endpoint_auth_method": "none",
+    }
+    config._write_config({"human_id": "keep-me", "oauth": previous})
+
+    def fail_revocation(data: dict) -> bool:
+        assert data == previous
+        raise OAuthError("old session revocation failed")
+
+    monkeypatch.setattr(config, "_revoke_stored_oauth", fail_revocation)
+
+    with pytest.raises(OAuthError, match="old session revocation failed"):
+        config.save_api_key("tvly-replacement")
+
+    assert config._read_config() == {"human_id": "keep-me", "oauth": previous}
+
+
+def test_save_oauth_session_revokes_previous_before_overwrite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tavily_cli import config
+    from tavily_cli.oauth import OAuthSession, OAuthTokens
+
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
+    previous = {
+        "access_token": "old-access",
+        "refresh_token": "old-refresh",
+        "client_id": "old-client",
+        "token_endpoint_auth_method": "none",
+    }
+    config._write_config({"oauth": previous})
+    replacement = OAuthSession(
+        tokens=OAuthTokens(
+            access_token="new-access",
+            refresh_token="new-refresh",
+            expires_at=expires_at_from_now(3600),
+        ),
+        client=RegisteredClient(
+            client_id="new-client",
+            client_secret=None,
+            token_endpoint_auth_method="none",
+            redirect_uri="http://127.0.0.1:2/callback",
+        ),
+    )
+    revoked: list[dict] = []
+
+    def revoke_before_overwrite(data: dict) -> bool:
+        assert config._read_config()["oauth"] == previous
+        revoked.append(data)
+        return True
+
+    monkeypatch.setattr(config, "_revoke_stored_oauth", revoke_before_overwrite)
+
+    config.save_oauth_session(replacement)
+
+    stored = config._read_config()["oauth"]
+    assert revoked == [previous]
+    assert stored["access_token"] == "new-access"
+    assert stored["refresh_token"] == "new-refresh"
+    assert stored["client_id"] == "new-client"
+
+
+def test_save_oauth_session_keeps_previous_and_cleans_replacement_on_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tavily_cli import config
+    from tavily_cli.oauth import OAuthSession, OAuthTokens
+
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
+    previous = {
+        "access_token": "old-access",
+        "refresh_token": "old-refresh",
+        "client_id": "old-client",
+        "token_endpoint_auth_method": "none",
+    }
+    config._write_config({"oauth": previous})
+    replacement = OAuthSession(
+        tokens=OAuthTokens(
+            access_token="new-access",
+            refresh_token="new-refresh",
+            expires_at=expires_at_from_now(3600),
+        ),
+        client=RegisteredClient(
+            client_id="new-client",
+            client_secret=None,
+            token_endpoint_auth_method="none",
+            redirect_uri="http://127.0.0.1:2/callback",
+        ),
+    )
+    revocation_attempts: list[dict] = []
+
+    def fail_previous_then_clean_replacement(data: dict) -> bool:
+        revocation_attempts.append(data)
+        if len(revocation_attempts) == 1:
+            raise OAuthError("old session revocation failed")
+        return True
+
+    monkeypatch.setattr(config, "_revoke_stored_oauth", fail_previous_then_clean_replacement)
+
+    with pytest.raises(OAuthError, match="Could not replace the previous OAuth session"):
+        config.save_oauth_session(replacement)
+
+    assert config._read_config() == {"oauth": previous}
+    assert revocation_attempts[0] == previous
+    assert revocation_attempts[1]["refresh_token"] == "new-refresh"
+    assert revocation_attempts[1]["client_id"] == "new-client"
+
+
+def test_refresh_persists_tokens_without_revoking_active_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tavily_cli import config, oauth
+    from tavily_cli.oauth import OAuthTokens
+
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
+    previous = {
+        "access_token": "old-access",
+        "refresh_token": "same-refresh",
+        "expires_at": 0,
+        "token_type": "Bearer",
+        "client_id": "same-client",
+        "client_secret": None,
+        "token_endpoint_auth_method": "none",
+        "redirect_uri": "http://127.0.0.1:1/callback",
+    }
+    config._write_config({"oauth": previous})
+
+    monkeypatch.setattr(oauth, "fetch_metadata", lambda: object())
+    monkeypatch.setattr(
+        oauth,
+        "refresh_tokens",
+        lambda metadata, client, refresh_token: OAuthTokens(
+            access_token="new-access",
+            refresh_token=refresh_token,
+            expires_at=expires_at_from_now(3600),
+        ),
+    )
+    monkeypatch.setattr(
+        config,
+        "_revoke_stored_oauth",
+        lambda data: pytest.fail("automatic refresh must not revoke the active session"),
+    )
+
+    access_token = config._get_oauth_access_token(config._read_config())
+
+    assert access_token == "new-access"
+    stored = config._read_config()["oauth"]
+    assert stored["access_token"] == "new-access"
+    assert stored["refresh_token"] == "same-refresh"
+    assert stored["client_id"] == "same-client"
+
+
+def test_api_key_login_json_reports_replacement_revocation_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tavily_cli.commands import auth
+
+    def fail_save(api_key: str) -> None:
+        raise OAuthError("old session revocation failed")
+
+    monkeypatch.setattr(auth, "save_api_key", fail_save)
+
+    result = CliRunner().invoke(auth.login, ["--api-key", "tvly-replacement", "--json"])
+
+    assert result.exit_code == 3
+    assert json.loads(result.stdout) == {
+        "authenticated": False,
+        "error": "old session revocation failed",
+    }
+
+
+def test_oauth_login_json_reports_replacement_revocation_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tavily_cli import oauth
+    from tavily_cli.commands import auth
+    from tavily_cli.oauth import OAuthSession, OAuthTokens
+
+    replacement = OAuthSession(
+        tokens=OAuthTokens(
+            access_token="new-access",
+            refresh_token="new-refresh",
+            expires_at=expires_at_from_now(3600),
+        ),
+        client=RegisteredClient(
+            client_id="new-client",
+            client_secret=None,
+            token_endpoint_auth_method="none",
+            redirect_uri="http://127.0.0.1:2/callback",
+        ),
+    )
+
+    monkeypatch.setattr(oauth, "looks_headless", lambda: False)
+    monkeypatch.setattr(oauth, "run_browser_login", lambda **kwargs: replacement)
+
+    def fail_save(session: OAuthSession) -> None:
+        raise OAuthError("old session revocation failed")
+
+    monkeypatch.setattr(auth, "save_oauth_session", fail_save)
+
+    result = CliRunner().invoke(auth.login, ["--json"])
+
+    assert result.exit_code == 3
+    assert json.loads(result.stdout) == {
+        "authenticated": False,
+        "error": "old session revocation failed",
+    }
+
+
 def test_api_key_and_oauth_replace_each_other(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from tavily_cli import config
     from tavily_cli.oauth import OAuthSession, OAuthTokens
@@ -456,6 +678,9 @@ def test_api_key_and_oauth_replace_each_other(tmp_path: Path, monkeypatch: pytes
     stored = config._read_config()
     assert "api_key" not in stored
 
+    revoked: list[dict] = []
+    monkeypatch.setattr(config, "_revoke_stored_oauth", lambda data: revoked.append(data) or True)
     config.save_api_key("tvly-other")
     assert config.get_api_key() == "tvly-other"
     assert not config.has_stored_oauth()
+    assert revoked == [stored["oauth"]]

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -44,6 +44,14 @@ def test_token_expiry_skew() -> None:
     assert token_is_expired(None)
 
 
+@pytest.mark.parametrize(
+    "expires_at",
+    ["bad", True, [], {}, float("nan"), float("inf"), float("-inf")],
+)
+def test_malformed_token_expiry_is_expired(expires_at: object) -> None:
+    assert token_is_expired(expires_at)
+
+
 def test_authorize_url_includes_pkce_and_resource() -> None:
     metadata = OAuthMetadata(
         authorization_endpoint="https://mcp.tavily.com/authorize",
@@ -639,7 +647,7 @@ def test_save_oauth_session_keeps_previous_and_cleans_replacement_on_failure(
     assert revocation_attempts[1]["client_id"] == "new-client"
 
 
-def test_refresh_persists_tokens_without_revoking_active_session(
+def test_malformed_expiry_refreshes_without_revoking_active_session(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -651,7 +659,7 @@ def test_refresh_persists_tokens_without_revoking_active_session(
     previous = {
         "access_token": "old-access",
         "refresh_token": "same-refresh",
-        "expires_at": 0,
+        "expires_at": "bad",
         "token_type": "Bearer",
         "client_id": "same-client",
         "client_secret": None,
@@ -683,6 +691,19 @@ def test_refresh_persists_tokens_without_revoking_active_session(
     assert stored["access_token"] == "new-access"
     assert stored["refresh_token"] == "same-refresh"
     assert stored["client_id"] == "same-client"
+
+
+def test_malformed_expiry_without_refresh_is_invalid() -> None:
+    from tavily_cli import config
+
+    access_token = config._get_oauth_access_token({
+        "oauth": {
+            "access_token": "old-access",
+            "expires_at": "bad",
+        },
+    })
+
+    assert access_token is None
 
 
 def test_api_key_login_json_reports_replacement_revocation_failure(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Replace `npx mcp-remote` login with a native MCP OAuth 2.1 flow (PKCE, DCR, loopback callback).
- Store and refresh tokens in `~/.tavily/config.json` instead of polling `~/.mcp-auth`.
- Add `--no-browser` / `--json` on login, revoke on logout, and keep legacy mcp-auth tokens as a fallback.

## Test plan
- [ ] `tvly login` opens the browser and writes `~/.tavily/config.json`
- [ ] `tvly auth --json` reports `"method": "oauth"`
- [ ] `tvly logout` clears credentials; `tvly --status` shows unauthenticated
- [ ] `tvly login --api-key` still works and replaces OAuth
- [ ] `python -m pytest tests/test_oauth.py`


Made with [Cursor](https://cursor.com)