### PR TITLE
Add one-shot tvly init setup

### DIFF
--- a/tavily_cli/cli.py
+++ b/tavily_cli/cli.py
@@ -8,6 +8,7 @@ from tavily_cli import __version__
 from tavily_cli.commands.auth import auth_status, login, logout
 from tavily_cli.commands.crawl import crawl
 from tavily_cli.commands.extract import extract
+from tavily_cli.commands.init import init_command
 from tavily_cli.commands.map_cmd import map_urls
 from tavily_cli.commands.research import research
 from tavily_cli.commands.search import search
@@ -142,6 +143,7 @@ def _print_status(json_output: bool) -> None:
 cli.add_command(login)
 cli.add_command(logout)
 cli.add_command(auth_status)
+cli.add_command(init_command)
 cli.add_command(search)
 cli.add_command(extract)
 cli.add_command(crawl)

--- a/tavily_cli/commands/init.py
+++ b/tavily_cli/commands/init.py
@@ -1,0 +1,263 @@
+"""One-shot Tavily CLI and agent skill setup."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+from typing import Any
+
+import click
+
+from tavily_cli import __version__
+from tavily_cli.common import json_option
+from tavily_cli.init_skills import (
+    SKILLS_SOURCE,
+    agent_specs,
+    detect_agents,
+    install_skills,
+    verify_skills,
+)
+
+_AGENT_CHOICES = tuple(agent_specs())
+
+
+@click.command("init")
+@click.option(
+    "--agent",
+    "agents",
+    type=click.Choice(_AGENT_CHOICES, case_sensitive=False),
+    multiple=True,
+    help="Install skills for an agent. Repeat to select more than one.",
+)
+@click.option("--all", "all_agents", is_flag=True, help="Install skills for every detected agent.")
+@click.option("--yes", "assume_yes", is_flag=True, help="Accept detected agents without prompting.")
+@click.option("--skip-auth", is_flag=True, help="Keep keyless mode when no credential is configured.")
+@click.option("--skip-skills", is_flag=True, help="Do not install or update Tavily agent skills.")
+@click.option("--api-key", default=None, help="Authenticate with a Tavily API key instead of OAuth.")
+@click.option(
+    "--browser/--no-browser",
+    default=None,
+    help="Open OAuth in a browser, or print the URL and wait for its local callback.",
+)
+@json_option
+def init_command(
+    agents: tuple[str, ...],
+    all_agents: bool,
+    assume_yes: bool,
+    skip_auth: bool,
+    skip_skills: bool,
+    api_key: str | None,
+    browser: bool | None,
+    json_output: bool,
+) -> None:
+    """Authenticate, install Tavily skills, and verify a working CLI."""
+    if all_agents and agents:
+        raise click.UsageError("Use either --all or --agent, not both.")
+    if skip_auth and api_key:
+        raise click.UsageError("Use either --skip-auth or --api-key, not both.")
+
+    selected_agents = _select_agents(agents, all_agents, assume_yes, skip_skills, json_output)
+    result = _empty_result(selected_agents)
+    result["skills"]["skipped"] = skip_skills
+
+    try:
+        auth = _ensure_auth(api_key=api_key, skip_auth=skip_auth, browser=browser, json_output=json_output)
+    except Exception as exc:
+        _fail(result, "auth", str(exc), 3, json_output)
+        return
+    result["auth"] = auth
+    result["mode"] = "authenticated" if auth["authenticated"] else "keyless"
+    result["verification"]["auth"] = auth["authenticated"]
+
+    if not skip_skills:
+        try:
+            skills_result = install_skills(selected_agents)
+            result["skills"].update({
+                "installed": skills_result.installed,
+                "updated": skills_result.updated,
+                "unchanged": skills_result.unchanged,
+                "total": skills_result.total,
+                "linked": skills_result.linked,
+                "restart_required": skills_result.restart_required,
+            })
+            result["verification"]["skills"] = verify_skills(selected_agents)
+            if not result["verification"]["skills"]:
+                raise RuntimeError("Installed Tavily skills could not be verified.")
+        except Exception as exc:
+            _fail(result, "skills", str(exc), 1, json_output)
+            return
+
+    result["verification"]["cli"] = _verify_cli()
+    if not result["verification"]["cli"]:
+        _fail(result, "cli", "tvly is not available on PATH.", 1, json_output)
+        return
+
+    try:
+        result["verification"]["live_search"] = _verify_live_search()
+    except Exception as exc:
+        _fail(result, "live_search", str(exc), 4, json_output)
+        return
+    if not result["verification"]["live_search"]:
+        _fail(result, "live_search", "Tavily search returned no result payload.", 4, json_output)
+        return
+
+    result["ok"] = True
+    _print_result(result, json_output=json_output)
+
+
+def _select_agents(
+    requested: tuple[str, ...],
+    all_agents: bool,
+    assume_yes: bool,
+    skip_skills: bool,
+    json_output: bool,
+) -> tuple[str, ...]:
+    if skip_skills:
+        return ()
+    if requested:
+        return tuple(dict.fromkeys(name.lower() for name in requested))
+
+    detected = detect_agents()
+    if not detected or all_agents or assume_yes or json_output or not sys.stdin.isatty():
+        return detected
+
+    label = ", ".join(detected)
+    if click.confirm(f"Install Tavily skills for detected agents ({label})?", default=True):
+        return detected
+    return ()
+
+
+def _ensure_auth(
+    *,
+    api_key: str | None,
+    skip_auth: bool,
+    browser: bool | None,
+    json_output: bool,
+) -> dict[str, Any]:
+    from tavily_cli.config import get_api_key, save_api_key, save_oauth_session
+
+    if api_key:
+        save_api_key(api_key)
+    key = get_api_key()
+    if key:
+        return {"authenticated": True, "method": _auth_method(key)}
+    if skip_auth:
+        return {"authenticated": False, "method": "none"}
+
+    if browser is None and not sys.stdin.isatty():
+        raise RuntimeError(
+            "No Tavily credential found. Use --api-key, --browser, --no-browser, or --skip-auth in non-interactive runs."
+        )
+
+    from tavily_cli.oauth import looks_headless, run_browser_login
+
+    open_browser = browser if browser is not None else not looks_headless()
+
+    def show_url(url: str) -> None:
+        click.echo(f"Open this URL to authenticate: {url}", err=True)
+
+    session = run_browser_login(open_browser=open_browser, on_status=show_url)
+    save_oauth_session(session)
+    return {"authenticated": True, "method": "oauth"}
+
+
+def _auth_method(key: str) -> str:
+    from tavily_cli.config import has_stored_oauth, is_oauth_token
+
+    if os.environ.get("TAVILY_API_KEY"):
+        return "env"
+    if is_oauth_token(key):
+        return "oauth" if has_stored_oauth() else "oauth_legacy"
+    return "api_key"
+
+
+def _verify_cli() -> bool:
+    return shutil.which("tvly") is not None
+
+
+def _verify_live_search() -> bool:
+    from tavily_cli.config import get_client_or_keyless
+
+    client, _ = get_client_or_keyless(client_name="tavily-cli-init")
+    response = client.search(query="Tavily Search API", max_results=1)
+    return isinstance(response, dict) and isinstance(response.get("results"), list)
+
+
+def _empty_result(agents: tuple[str, ...]) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "version": __version__,
+        "mode": "unknown",
+        "auth": {"authenticated": False, "method": "none"},
+        "skills": {
+            "source": SKILLS_SOURCE,
+            "agents": list(agents),
+            "installed": 0,
+            "updated": 0,
+            "unchanged": 0,
+            "total": 0,
+            "linked": 0,
+            "restart_required": False,
+            "skipped": False,
+        },
+        "verification": {
+            "cli": False,
+            "auth": False,
+            "skills": None,
+            "live_search": False,
+        },
+    }
+
+
+def _fail(result: dict[str, Any], stage: str, message: str, exit_code: int, json_output: bool) -> None:
+    result["error"] = {"stage": stage, "message": message}
+    _print_result(result, json_output=json_output)
+    raise click.exceptions.Exit(exit_code)
+
+
+def _print_result(result: dict[str, Any], *, json_output: bool) -> None:
+    if json_output:
+        click.echo(json.dumps(result, sort_keys=True))
+        return
+
+    from rich.markup import escape
+
+    from tavily_cli.common import sanitize_control
+    from tavily_cli.theme import console
+
+    console.print()
+    if result["ok"]:
+        console.print("  [bold #9BC0AE]> Tavily is ready[/bold #9BC0AE]")
+    else:
+        error = result.get("error", {})
+        message = escape(sanitize_control(error.get("message", "Initialization failed.")))
+        console.print(f"  [bold #FAA2FB]> Setup failed:[/bold #FAA2FB] {message}")
+        console.print()
+        return
+
+    auth = result["auth"]
+    if auth["authenticated"]:
+        console.print(f"    [#9BC0AE]✓[/#9BC0AE] Authenticated via {auth['method']}")
+    else:
+        console.print("    [#FFC769]•[/#FFC769] Keyless mode")
+
+    skills = result["skills"]
+    if skills["skipped"]:
+        console.print("    [dim]• Skills skipped[/dim]")
+    else:
+        agents = ", ".join(skills["agents"]) or "shared agent directory"
+        console.print(f"    [#9BC0AE]✓[/#9BC0AE] {skills['total']} Tavily skills ready for {agents}")
+    console.print("    [#9BC0AE]✓[/#9BC0AE] Live search verified")
+
+    if skills["restart_required"] and skills["agents"]:
+        console.print()
+        console.print(f"    [dim]Restart {', '.join(skills['agents'])} to load newly installed skills.[/dim]")
+
+    console.print()
+    console.print("  Try:")
+    console.print('    [#9BC0AE]tvly search "latest AI news"[/#9BC0AE]')
+    console.print("    [#9BC0AE]tvly extract https://example.com[/#9BC0AE]")
+    console.print("    [#9BC0AE]tvly research \"your topic\"[/#9BC0AE]")
+    console.print()

--- a/tavily_cli/init_skills.py
+++ b/tavily_cli/init_skills.py
@@ -1,0 +1,313 @@
+"""Install Tavily's maintained agent skills without requiring Node.js."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import shutil
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from uuid import uuid4
+
+import httpx
+
+SKILLS_SOURCE = "tavily-ai/skills"
+SKILLS_ARCHIVE_URL = "https://codeload.github.com/tavily-ai/skills/tar.gz/refs/heads/main"
+CORE_SKILLS = (
+    "tavily-best-practices",
+    "tavily-cli",
+    "tavily-crawl",
+    "tavily-dynamic-search",
+    "tavily-extract",
+    "tavily-map",
+    "tavily-research",
+    "tavily-search",
+)
+
+_MAX_ARCHIVE_BYTES = 25 * 1024 * 1024
+_MAX_FILE_BYTES = 5 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    marker: Path
+    skills_dir: Path
+
+
+@dataclass(frozen=True)
+class SkillsInstallResult:
+    agents: tuple[str, ...]
+    installed: int
+    updated: int
+    unchanged: int
+    linked: int
+    restart_required: bool
+
+    @property
+    def total(self) -> int:
+        return self.installed + self.updated + self.unchanged
+
+
+def agent_specs(home: Path | None = None) -> dict[str, AgentSpec]:
+    """Return supported agent locations rooted at the current user's home."""
+    root = home or Path.home()
+    if home is None:
+        claude_root = Path(os.environ.get("CLAUDE_CONFIG_DIR", root / ".claude")).expanduser()
+        codex_root = Path(os.environ.get("CODEX_HOME", root / ".codex")).expanduser()
+    else:
+        claude_root = root / ".claude"
+        codex_root = root / ".codex"
+    return {
+        "claude-code": AgentSpec(claude_root, claude_root / "skills"),
+        "codex": AgentSpec(codex_root, codex_root / "skills"),
+        "cursor": AgentSpec(root / ".cursor", root / ".cursor" / "skills"),
+    }
+
+
+def detect_agents(home: Path | None = None) -> tuple[str, ...]:
+    """Detect supported agents from their existing configuration directories."""
+    return tuple(name for name, spec in agent_specs(home).items() if spec.marker.is_dir())
+
+
+def download_skills_archive(*, client: httpx.Client | None = None) -> bytes:
+    """Download the canonical skills archive with a conservative size limit."""
+    http = client or httpx.Client(timeout=30.0, follow_redirects=True)
+    close = client is None
+    try:
+        chunks: list[bytes] = []
+        size = 0
+        with http.stream("GET", SKILLS_ARCHIVE_URL) as response:
+            response.raise_for_status()
+            for chunk in response.iter_bytes():
+                size += len(chunk)
+                if size > _MAX_ARCHIVE_BYTES:
+                    raise ValueError("Tavily skills archive exceeds the 25 MB safety limit.")
+                chunks.append(chunk)
+        return b"".join(chunks)
+    finally:
+        if close:
+            http.close()
+
+
+def install_skills(
+    agents: tuple[str, ...],
+    *,
+    home: Path | None = None,
+    archive: bytes | None = None,
+) -> SkillsInstallResult:
+    """Install the eight core skills and expose them to selected agents.
+
+    Archive scripts and references are copied as files but are never executed.
+    Only the exact Tavily skill names in ``CORE_SKILLS`` are managed.
+    """
+    root = home or Path.home()
+    specs = agent_specs(home)
+    unsupported = sorted(set(agents) - set(specs))
+    if unsupported:
+        raise ValueError(f"Unsupported agent(s): {', '.join(unsupported)}")
+
+    shared_root = root / ".agents" / "skills"
+    shared_root.mkdir(parents=True, exist_ok=True)
+
+    installed = 0
+    updated = 0
+    unchanged = 0
+    linked = 0
+    archive_data = archive if archive is not None else download_skills_archive()
+
+    with tempfile.TemporaryDirectory(prefix="tavily-skills-") as temp_dir:
+        extracted_root = Path(temp_dir)
+        _extract_core_skills(archive_data, extracted_root)
+        _preflight_install(shared_root, agents, specs)
+
+        for skill_name in CORE_SKILLS:
+            source = extracted_root / skill_name
+            destination = shared_root / skill_name
+            state = _replace_if_changed(source, destination)
+            if state == "installed":
+                installed += 1
+            elif state == "updated":
+                updated += 1
+            else:
+                unchanged += 1
+
+        for agent_name in agents:
+            skills_dir = specs[agent_name].skills_dir
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            for skill_name in CORE_SKILLS:
+                if _expose_skill(shared_root / skill_name, skills_dir / skill_name):
+                    linked += 1
+
+    changed = installed > 0 or updated > 0 or linked > 0
+    return SkillsInstallResult(
+        agents=agents,
+        installed=installed,
+        updated=updated,
+        unchanged=unchanged,
+        linked=linked,
+        restart_required=changed,
+    )
+
+
+def verify_skills(agents: tuple[str, ...], *, home: Path | None = None) -> bool:
+    """Verify shared skill files and selected agent entries are present."""
+    root = home or Path.home()
+    specs = agent_specs(home)
+    shared_root = root / ".agents" / "skills"
+    for skill_name in CORE_SKILLS:
+        if not (shared_root / skill_name / "SKILL.md").is_file():
+            return False
+    for agent_name in agents:
+        spec = specs.get(agent_name)
+        if spec is None:
+            return False
+        for skill_name in CORE_SKILLS:
+            if not (spec.skills_dir / skill_name / "SKILL.md").is_file():
+                return False
+    return True
+
+
+def _extract_core_skills(archive_data: bytes, destination: Path) -> None:
+    """Extract only approved skill directories from an untrusted tar archive."""
+    found: set[str] = set()
+    total_file_bytes = 0
+    try:
+        archive = tarfile.open(fileobj=io.BytesIO(archive_data), mode="r:gz")
+    except tarfile.TarError as exc:
+        raise ValueError("Downloaded Tavily skills archive is invalid.") from exc
+
+    with archive:
+        for member in archive.getmembers():
+            path = PurePosixPath(member.name)
+            parts = path.parts
+            if path.is_absolute() or ".." in parts or len(parts) < 4:
+                continue
+            if parts[1] != "skills" or parts[2] not in CORE_SKILLS:
+                continue
+
+            skill_name = parts[2]
+            relative_parts = parts[3:]
+            if not relative_parts:
+                continue
+            if any(part in ("", ".", "..") or "\\" in part or ":" in part for part in relative_parts):
+                raise ValueError(f"Tavily skill {skill_name} contains an unsafe archive path.")
+            target = destination / skill_name / Path(*relative_parts)
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            if not member.isfile():
+                raise ValueError(f"Tavily skill {skill_name} contains an unsupported archive entry.")
+            if member.size > _MAX_FILE_BYTES:
+                raise ValueError(f"Tavily skill {skill_name} contains a file larger than 5 MB.")
+            total_file_bytes += member.size
+            if total_file_bytes > _MAX_ARCHIVE_BYTES:
+                raise ValueError("Extracted Tavily skills exceed the 25 MB safety limit.")
+
+            source = archive.extractfile(member)
+            if source is None:
+                raise ValueError(f"Could not read {member.name} from the Tavily skills archive.")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(source.read())
+            target.chmod(0o755 if member.mode & 0o111 else 0o644)
+            found.add(skill_name)
+
+    missing = [name for name in CORE_SKILLS if name not in found or not (destination / name / "SKILL.md").is_file()]
+    if missing:
+        raise ValueError(f"Tavily skills archive is missing: {', '.join(missing)}")
+
+
+def _directory_digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    entries = sorted(path.rglob("*"))
+    if any(item.is_symlink() for item in entries):
+        raise ValueError(f"Cannot compare a skill containing links: {path}")
+    for file_path in (item for item in entries if item.is_file()):
+        relative = file_path.relative_to(path).as_posix().encode("utf-8")
+        content = file_path.read_bytes()
+        digest.update(len(relative).to_bytes(4, "big"))
+        digest.update(relative)
+        digest.update((file_path.stat().st_mode & 0o111).to_bytes(2, "big"))
+        digest.update(len(content).to_bytes(8, "big"))
+        digest.update(content)
+    return digest.hexdigest()
+
+
+def _replace_if_changed(source: Path, destination: Path) -> str:
+    existed = destination.exists() or destination.is_symlink()
+    if destination.is_dir() and not destination.is_symlink():
+        if _directory_digest(source) == _directory_digest(destination):
+            return "unchanged"
+    elif existed:
+        raise ValueError(f"Cannot install Tavily skill over non-directory path: {destination}")
+
+    token = uuid4().hex
+    staging = destination.parent / f".{destination.name}.tavily-new-{token}"
+    backup = destination.parent / f".{destination.name}.tavily-backup-{token}"
+
+    shutil.copytree(source, staging)
+    try:
+        if existed:
+            destination.replace(backup)
+        staging.replace(destination)
+    except Exception:
+        if not destination.exists() and backup.exists():
+            backup.replace(destination)
+        raise
+    else:
+        if backup.exists() or backup.is_symlink():
+            try:
+                _remove_path(backup)
+            except OSError:
+                pass
+    finally:
+        if staging.exists() or staging.is_symlink():
+            _remove_path(staging)
+    return "updated" if existed else "installed"
+
+
+def _expose_skill(source: Path, destination: Path) -> bool:
+    if destination.is_symlink():
+        if destination.resolve(strict=False) == source.resolve():
+            return False
+        raise ValueError(f"Cannot replace existing skill link: {destination}")
+    if destination.exists():
+        if not destination.is_dir():
+            raise ValueError(f"Cannot replace non-directory skill path: {destination}")
+        return _replace_if_changed(source, destination) != "unchanged"
+
+    relative_source = os.path.relpath(source, start=destination.parent)
+    try:
+        destination.symlink_to(relative_source, target_is_directory=True)
+    except OSError:
+        shutil.copytree(source, destination)
+    return True
+
+
+def _preflight_install(shared_root: Path, agents: tuple[str, ...], specs: dict[str, AgentSpec]) -> None:
+    """Reject path conflicts before changing any installed skill."""
+    for skill_name in CORE_SKILLS:
+        destination = shared_root / skill_name
+        if (destination.exists() or destination.is_symlink()) and (
+            destination.is_symlink() or not destination.is_dir()
+        ):
+            raise ValueError(f"Cannot install Tavily skill over non-directory path: {destination}")
+
+    for agent_name in agents:
+        for skill_name in CORE_SKILLS:
+            source = shared_root / skill_name
+            destination = specs[agent_name].skills_dir / skill_name
+            if destination.is_symlink():
+                if destination.resolve(strict=False) != source.resolve(strict=False):
+                    raise ValueError(f"Cannot replace existing skill link: {destination}")
+            elif destination.exists() and not destination.is_dir():
+                raise ValueError(f"Cannot replace non-directory skill path: {destination}")
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,189 @@
+"""Tests for one-shot CLI and agent skill setup."""
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from tavily_cli.cli import cli
+from tavily_cli.commands import init as init_module
+from tavily_cli.init_skills import (
+    CORE_SKILLS,
+    SkillsInstallResult,
+    detect_agents,
+    install_skills,
+    verify_skills,
+)
+
+
+def _skills_archive(*, changed_skill: str | None = None, symlink: bool = False) -> bytes:
+    payload = io.BytesIO()
+    with tarfile.open(fileobj=payload, mode="w:gz") as archive:
+        for skill_name in CORE_SKILLS:
+            content = f"---\nname: {skill_name}\n---\n"
+            if skill_name == changed_skill:
+                content += "updated\n"
+            _add_file(archive, f"skills-main/skills/{skill_name}/SKILL.md", content.encode())
+        _add_file(
+            archive,
+            "skills-main/skills/tavily-cli/scripts/check.sh",
+            b"#!/bin/sh\nexit 99\n",
+            mode=0o755,
+        )
+        if symlink:
+            member = tarfile.TarInfo("skills-main/skills/tavily-cli/references/unsafe")
+            member.type = tarfile.SYMTYPE
+            member.linkname = "/etc/passwd"
+            archive.addfile(member)
+    return payload.getvalue()
+
+
+def _add_file(archive: tarfile.TarFile, name: str, content: bytes, *, mode: int = 0o644) -> None:
+    member = tarfile.TarInfo(name)
+    member.size = len(content)
+    member.mode = mode
+    archive.addfile(member, io.BytesIO(content))
+
+
+def test_detect_agents_only_returns_existing_markers(tmp_path: Path) -> None:
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".config" / "opencode").mkdir(parents=True)
+
+    assert detect_agents(tmp_path) == ("codex",)
+
+
+def test_skill_install_honors_custom_agent_directories(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    default_home = tmp_path / "home"
+    codex_home = tmp_path / "custom-codex"
+    claude_home = tmp_path / "custom-claude"
+    default_home.mkdir()
+    codex_home.mkdir()
+    claude_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: default_home)
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_home))
+
+    assert detect_agents() == ("claude-code", "codex")
+
+    install_skills(("claude-code", "codex"), archive=_skills_archive())
+
+    assert verify_skills(("claude-code", "codex"))
+    assert (claude_home / "skills" / "tavily-search" / "SKILL.md").is_file()
+    assert (codex_home / "skills" / "tavily-search" / "SKILL.md").is_file()
+    assert not (default_home / ".claude").exists()
+    assert not (default_home / ".codex").exists()
+
+
+def test_skill_install_is_complete_and_idempotent(tmp_path: Path) -> None:
+    archive = _skills_archive()
+
+    first = install_skills(("codex",), home=tmp_path, archive=archive)
+
+    assert first.installed == len(CORE_SKILLS)
+    assert first.updated == 0
+    assert first.linked == len(CORE_SKILLS)
+    assert first.restart_required
+    assert verify_skills(("codex",), home=tmp_path)
+    script = tmp_path / ".agents" / "skills" / "tavily-cli" / "scripts" / "check.sh"
+    assert script.read_text() == "#!/bin/sh\nexit 99\n"
+    assert script.stat().st_mode & 0o111
+
+    second = install_skills(("codex",), home=tmp_path, archive=archive)
+
+    assert second.installed == 0
+    assert second.updated == 0
+    assert second.unchanged == len(CORE_SKILLS)
+    assert second.linked == 0
+    assert not second.restart_required
+
+
+def test_skill_install_without_agent_uses_shared_directory(tmp_path: Path) -> None:
+    result = install_skills((), home=tmp_path, archive=_skills_archive())
+
+    assert result.agents == ()
+    assert result.installed == len(CORE_SKILLS)
+    assert result.linked == 0
+    assert verify_skills((), home=tmp_path)
+
+
+def test_skill_install_updates_only_changed_core_skill(tmp_path: Path) -> None:
+    install_skills(("claude-code",), home=tmp_path, archive=_skills_archive())
+
+    updated = install_skills(
+        ("claude-code",),
+        home=tmp_path,
+        archive=_skills_archive(changed_skill="tavily-search"),
+    )
+
+    assert updated.updated == 1
+    assert updated.unchanged == len(CORE_SKILLS) - 1
+    assert "updated" in (tmp_path / ".agents" / "skills" / "tavily-search" / "SKILL.md").read_text()
+
+
+def test_skill_install_rejects_archive_links(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unsupported archive entry"):
+        install_skills((), home=tmp_path, archive=_skills_archive(symlink=True))
+
+
+def test_skill_install_checks_conflicts_before_writing(tmp_path: Path) -> None:
+    conflict = tmp_path / ".agents" / "skills" / CORE_SKILLS[-1]
+    conflict.parent.mkdir(parents=True)
+    conflict.write_text("owned by the user")
+
+    with pytest.raises(ValueError, match="non-directory path"):
+        install_skills((), home=tmp_path, archive=_skills_archive())
+
+    assert not (tmp_path / ".agents" / "skills" / CORE_SKILLS[0]).exists()
+
+
+def test_init_json_reuses_environment_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(init_module, "detect_agents", lambda: ("codex",))
+    monkeypatch.setattr(
+        init_module,
+        "install_skills",
+        lambda agents: SkillsInstallResult(agents, 8, 0, 0, 8, True),
+    )
+    monkeypatch.setattr(init_module, "verify_skills", lambda agents: True)
+    monkeypatch.setattr(init_module, "_verify_cli", lambda: True)
+    monkeypatch.setattr(init_module, "_verify_live_search", lambda: True)
+
+    result = CliRunner().invoke(cli, ["init", "--json"], env={"TAVILY_API_KEY": "tvly-test"})
+
+    assert result.exit_code == 0
+    output = json.loads(result.stdout)
+    assert output["ok"] is True
+    assert output["auth"] == {"authenticated": True, "method": "env"}
+    assert output["skills"]["agents"] == ["codex"]
+    assert output["verification"]["live_search"] is True
+
+
+def test_init_noninteractive_auth_failure_is_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tavily_cli import config
+
+    monkeypatch.setattr(config, "get_api_key", lambda: None)
+    result = CliRunner().invoke(cli, ["init", "--skip-skills", "--json"])
+
+    assert result.exit_code == 3
+    output = json.loads(result.stdout)
+    assert output["ok"] is False
+    assert output["error"]["stage"] == "auth"
+    assert output["skills"]["skipped"] is True
+
+
+def test_init_live_search_failure_exits_four(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(init_module, "_verify_cli", lambda: True)
+    monkeypatch.setattr(init_module, "_verify_live_search", lambda: False)
+
+    result = CliRunner().invoke(cli, ["init", "--skip-auth", "--skip-skills", "--json"])
+
+    assert result.exit_code == 4
+    output = json.loads(result.stdout)
+    assert output["error"]["stage"] == "live_search"


### PR DESCRIPTION
> Depends on #15. This PR is intentionally stacked on the native OAuth implementation.

## Summary

- Adds `tvly init` for authentication, agent detection, skill installation, and live verification
- Supports Claude Code, Codex, and Cursor
- Honors custom `CODEX_HOME` and `CLAUDE_CONFIG_DIR` paths
- Runs `tvly init` automatically from the shell installer
- Handles interactive and non-interactive installation

## Testing

- 19 tests passed
- Ruff passed
- Shell syntax validation passed