### PR TITLE
feat: add tvly self-update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ CLI and agent tools for the [Tavily API](https://docs.tavily.com) — search, ex
 - **Website Crawling** — Crawl sites with depth/breadth control and path filtering
 - **URL Discovery** — Map all URLs on a site without content extraction
 - **Deep Research** — AI-powered research with citations and structured output
+- **Self-Update** — Check for and install CLI updates through the original package manager
 
 ## Installation
 
@@ -30,6 +31,18 @@ git clone https://github.com/tavily-ai/tavily-cli.git
 cd tavily-cli
 pip install -e .
 ```
+
+### Updating
+
+```bash
+# Check without changing the installation
+tvly update --check
+
+# Update through uv, pipx, or pip
+tvly update
+```
+
+Source and direct-URL installations are detected and must be updated from their original source.
 
 ## Quick Start
 
@@ -168,6 +181,7 @@ tvly
 ├── extract <urls...>           # Extract content from URLs
 ├── crawl <url>                 # Crawl a website
 ├── map <url>                   # Discover URLs (no content)
+├── update                      # Check for or install CLI updates
 └── research <query>            # Deep research (async)
     ├── run <query>             # Start a research task (same as above)
     ├── status <id>             # Check task status
@@ -183,6 +197,7 @@ All commands support `--json` output and can be fully controlled via CLI argumen
 tvly search "query" --json
 tvly auth --json
 tvly extract https://example.com --json
+tvly update --check --json
 
 # Read input from stdin with "-"
 echo "What is the latest funding for Anthropic?" | tvly search - --json
@@ -204,9 +219,10 @@ tvly --status --json   # structured status
 | Code | Meaning |
 |------|---------|
 | 0 | Success |
+| 1 | Local setup or update error |
 | 2 | Invalid input / usage error |
 | 3 | Authentication error |
-| 4 | API error |
+| 4 | API or update-check error |
 
 ## Command Reference
 
@@ -229,6 +245,20 @@ tvly --status --json   # structured status
 | `--chunks-per-source` | Chunks per source (advanced/fast depth only) |
 | `-o` / `--output` | Save output to file |
 | `--client-name` | Set optional `client_name` for request attribution |
+
+### `tvly update`
+
+Check PyPI for the latest Tavily CLI release and update through the package
+manager responsible for the active installation.
+
+```bash
+tvly update --check
+tvly update
+tvly update --check --json
+```
+
+`--check` is read-only. Source/direct-URL installations are reported without
+being modified.
 
 ### `tvly extract`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "click>=8.1.0",
     "rich>=13.0.0",
     "httpx>=0.27.0",
+    "packaging>=23.2",
     "requests>=2.32.4",
     "urllib3>=2.2.2",
     "certifi>=2024.7.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tavily-cli"
-version = "0.1.6"
+version = "0.1.7"
 description = "CLI and agent tools for the Tavily API — search, extract, crawl, map, and research from the command line."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tavily_cli/cli.py
+++ b/tavily_cli/cli.py
@@ -11,6 +11,7 @@ from tavily_cli.commands.extract import extract
 from tavily_cli.commands.map_cmd import map_urls
 from tavily_cli.commands.research import research
 from tavily_cli.commands.search import search
+from tavily_cli.commands.update import update_command
 
 
 @click.group(invoke_without_command=True)
@@ -147,6 +148,7 @@ cli.add_command(extract)
 cli.add_command(crawl)
 cli.add_command(map_urls)
 cli.add_command(research)
+cli.add_command(update_command)
 
 
 def main() -> None:

--- a/tavily_cli/commands/update.py
+++ b/tavily_cli/commands/update.py
@@ -149,6 +149,10 @@ def detect_install(
     python = (executable or Path(sys.executable)).absolute()
     environment = (prefix or Path(sys.prefix)).resolve()
     runtime_environment = os.environ if process_environment is None else process_environment
+    installer = (dist.read_text("INSTALLER") or "").strip().lower()
+
+    if installer == "uv" and _is_uvx_environment(environment, runtime_environment):
+        return InstallInfo("uvx", None)
 
     if _is_source_install(dist):
         return InstallInfo("source", None)
@@ -187,7 +191,6 @@ def detect_install(
         command = (uv, "tool", "upgrade", PACKAGE_NAME) if uv and blocked_reason is None else None
         return InstallInfo("uv", command, tuple(manager_environment), blocked_reason)
 
-    installer = (dist.read_text("INSTALLER") or "").strip().lower()
     if installer == "uv":
         uv = which("uv")
         command = (uv, "pip", "install", "--python", str(python), "--upgrade", PACKAGE_NAME) if uv else None
@@ -239,6 +242,30 @@ def _missing_manager_bin_dir_message(manager: str, variable: str) -> str:
     )
 
 
+def _is_uvx_environment(environment: Path, process_environment: Mapping[str, str]) -> bool:
+    try:
+        active_environment = environment.resolve()
+    except (OSError, RuntimeError):
+        active_environment = environment.absolute()
+
+    configured_cache = process_environment.get("UV_CACHE_DIR")
+    if configured_cache:
+        try:
+            cache_dir = Path(configured_cache).expanduser().resolve()
+        except (OSError, RuntimeError):
+            cache_dir = Path(configured_cache).expanduser().absolute()
+        if active_environment == cache_dir or cache_dir in active_environment.parents:
+            return True
+
+    # uvx currently stores reusable run environments under an environments-vN
+    # entry that resolves into an archive-vN cache directory.
+    for part in active_environment.parts:
+        bucket, separator, version = part.lower().rpartition("-v")
+        if separator and bucket in {"archive", "environments"} and version.isdigit():
+            return True
+    return False
+
+
 def _is_source_install(distribution: metadata.Distribution) -> bool:
     raw = distribution.read_text("direct_url.json")
     if not raw:
@@ -278,6 +305,11 @@ def _installed_version() -> str:
 def _unsupported_install_message(method: str) -> str:
     if method == "source":
         return "This is a source or direct-URL installation. Update it from its original source."
+    if method == "uvx":
+        return (
+            "This CLI is running in a uvx cache environment and cannot update itself in place. "
+            "Exit and rerun uvx with the desired Tavily CLI version instead."
+        )
     if method in {"uv", "pipx"}:
         return f"This installation is managed by {method}, but {method} is not available on PATH."
     return "Could not determine how Tavily CLI was installed. Update it with the original package manager."

--- a/tavily_cli/commands/update.py
+++ b/tavily_cli/commands/update.py
@@ -153,9 +153,12 @@ def detect_install(
     if (environment / "pipx_metadata.json").is_file() or "/pipx/venvs/" in path:
         pipx = which("pipx")
         manager_environment: tuple[tuple[str, str], ...] = ()
+        # sys.prefix is the active pipx venv. Its directory name includes any
+        # suffix and is the identifier accepted by `pipx upgrade`.
+        pipx_environment = environment.name
         if environment.parent.name.lower() == "venvs":
             manager_environment = (("PIPX_HOME", str(environment.parent.parent)),)
-        return InstallInfo("pipx", (pipx, "upgrade", PACKAGE_NAME) if pipx else None, manager_environment)
+        return InstallInfo("pipx", (pipx, "upgrade", pipx_environment) if pipx else None, manager_environment)
 
     if (environment / "uv-receipt.toml").is_file() or "/uv/tools/" in path:
         uv = which("uv")

--- a/tavily_cli/commands/update.py
+++ b/tavily_cli/commands/update.py
@@ -8,7 +8,7 @@ import shutil
 import site
 import subprocess
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from importlib import metadata
 from pathlib import Path
@@ -31,6 +31,7 @@ class InstallInfo:
     method: str
     command: tuple[str, ...] | None
     environment: tuple[tuple[str, str], ...] = ()
+    blocked_reason: str | None = None
 
 
 @click.command("update")
@@ -61,7 +62,7 @@ def update_command(check_only: bool, json_output: bool) -> None:
         return
 
     if install.command is None:
-        message = _unsupported_install_message(install.method)
+        message = install.blocked_reason or _unsupported_install_message(install.method)
         _fail("install_method", message, 1, json_output)
         return
 
@@ -137,6 +138,8 @@ def detect_install(
     distribution: metadata.Distribution | None = None,
     executable: Path | None = None,
     prefix: Path | None = None,
+    entrypoint: Path | None = None,
+    process_environment: Mapping[str, str] | None = None,
     which: Callable[[str], str | None] = shutil.which,
 ) -> InstallInfo:
     """Detect the manager for the active package without changing the environment."""
@@ -145,6 +148,7 @@ def detect_install(
     # at the base interpreter and update the wrong environment.
     python = (executable or Path(sys.executable)).absolute()
     environment = (prefix or Path(sys.prefix)).resolve()
+    runtime_environment = os.environ if process_environment is None else process_environment
 
     if _is_source_install(dist):
         return InstallInfo("source", None)
@@ -152,18 +156,36 @@ def detect_install(
     path = f"{python.as_posix()}:{environment.as_posix()}".lower()
     if (environment / "pipx_metadata.json").is_file() or "/pipx/venvs/" in path:
         pipx = which("pipx")
-        manager_environment: tuple[tuple[str, str], ...] = ()
+        manager_environment: list[tuple[str, str]] = []
         # sys.prefix is the active pipx venv. Its directory name includes any
         # suffix and is the identifier accepted by `pipx upgrade`.
         pipx_environment = environment.name
         if environment.parent.name.lower() == "venvs":
-            manager_environment = (("PIPX_HOME", str(environment.parent.parent)),)
-        return InstallInfo("pipx", (pipx, "upgrade", pipx_environment) if pipx else None, manager_environment)
+            manager_environment.append(("PIPX_HOME", str(environment.parent.parent)))
+        bin_dir = _active_manager_bin_dir(
+            environment=environment,
+            entrypoint=entrypoint,
+            configured=runtime_environment.get("PIPX_BIN_DIR"),
+        )
+        if bin_dir is not None:
+            manager_environment.append(("PIPX_BIN_DIR", bin_dir))
+        blocked_reason = _missing_manager_bin_dir_message("pipx", "PIPX_BIN_DIR") if pipx and bin_dir is None else None
+        command = (pipx, "upgrade", pipx_environment) if pipx and blocked_reason is None else None
+        return InstallInfo("pipx", command, tuple(manager_environment), blocked_reason)
 
     if (environment / "uv-receipt.toml").is_file() or "/uv/tools/" in path:
         uv = which("uv")
-        manager_environment = (("UV_TOOL_DIR", str(environment.parent)),)
-        return InstallInfo("uv", (uv, "tool", "upgrade", PACKAGE_NAME) if uv else None, manager_environment)
+        manager_environment = [("UV_TOOL_DIR", str(environment.parent))]
+        bin_dir = _active_manager_bin_dir(
+            environment=environment,
+            entrypoint=entrypoint,
+            configured=runtime_environment.get("UV_TOOL_BIN_DIR"),
+        )
+        if bin_dir is not None:
+            manager_environment.append(("UV_TOOL_BIN_DIR", bin_dir))
+        blocked_reason = _missing_manager_bin_dir_message("uv", "UV_TOOL_BIN_DIR") if uv and bin_dir is None else None
+        command = (uv, "tool", "upgrade", PACKAGE_NAME) if uv and blocked_reason is None else None
+        return InstallInfo("uv", command, tuple(manager_environment), blocked_reason)
 
     installer = (dist.read_text("INSTALLER") or "").strip().lower()
     if installer == "uv":
@@ -176,6 +198,45 @@ def detect_install(
             command.insert(-2, "--user")
         return InstallInfo("pip", tuple(command))
     return InstallInfo("unknown", None)
+
+
+def _active_manager_bin_dir(*, environment: Path, entrypoint: Path | None, configured: str | None) -> str | None:
+    invoked = _invoked_entrypoint(entrypoint)
+    if invoked is not None:
+        try:
+            # Resolve the parent separately so the final launcher symlink stays
+            # visible while its target is checked against the active venv.
+            launcher = invoked.parent.resolve(strict=True) / invoked.name
+            target = launcher.resolve(strict=True)
+            active_environment = environment.resolve(strict=True)
+        except (OSError, RuntimeError):
+            pass
+        else:
+            target_is_active = target == active_environment or active_environment in target.parents
+            launcher_is_external = launcher != active_environment and active_environment not in launcher.parents
+            if target_is_active and launcher_is_external:
+                return str(launcher.parent)
+    return configured or None
+
+
+def _invoked_entrypoint(entrypoint: Path | None) -> Path | None:
+    raw = str(entrypoint) if entrypoint is not None else sys.argv[0]
+    if not raw:
+        return None
+    candidate = Path(raw)
+    if candidate.is_absolute():
+        return candidate
+    if os.sep in raw or (os.altsep is not None and os.altsep in raw):
+        return (Path.cwd() / candidate).absolute()
+    located = shutil.which(raw)
+    return Path(located).absolute() if located else None
+
+
+def _missing_manager_bin_dir_message(manager: str, variable: str) -> str:
+    return (
+        f"Could not safely determine {variable} for the active {manager} installation. "
+        f"Re-run with {variable} set to the directory containing this installation's tvly command."
+    )
 
 
 def _is_source_install(distribution: metadata.Distribution) -> bool:

--- a/tavily_cli/commands/update.py
+++ b/tavily_cli/commands/update.py
@@ -1,0 +1,260 @@
+"""Check for and install Tavily CLI updates."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import site
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from importlib import metadata
+from pathlib import Path
+
+import click
+import httpx
+from packaging.version import InvalidVersion, Version
+
+from tavily_cli import __version__
+from tavily_cli.common import json_option, sanitize_control
+
+PACKAGE_NAME = "tavily-cli"
+PYPI_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
+
+
+@dataclass(frozen=True)
+class InstallInfo:
+    """The package manager responsible for the active CLI installation."""
+
+    method: str
+    command: tuple[str, ...] | None
+    environment: tuple[tuple[str, str], ...] = ()
+
+
+@click.command("update")
+@click.option("--check", "check_only", is_flag=True, help="Check for an update without installing it.")
+@json_option
+def update_command(check_only: bool, json_output: bool) -> None:
+    """Check for or install the latest Tavily CLI release."""
+    try:
+        latest = fetch_latest_version()
+        update_available = _is_newer(latest, __version__)
+    except Exception as exc:
+        _fail("check", str(exc), 4, json_output)
+        return
+    try:
+        install = detect_install()
+    except Exception as exc:
+        _fail("install_method", str(exc), 1, json_output)
+        return
+
+    if check_only or not update_available:
+        result = _result(
+            current=__version__,
+            latest=latest,
+            install=install,
+            updated=False,
+        )
+        _print_result(result, json_output=json_output, check_only=check_only)
+        return
+
+    if install.command is None:
+        message = _unsupported_install_message(install.method)
+        _fail("install_method", message, 1, json_output)
+        return
+
+    if not json_output:
+        click.echo(f"Updating Tavily CLI via {install.method}...")
+
+    process_environment = os.environ.copy()
+    process_environment.update(install.environment)
+    try:
+        completed = subprocess.run(
+            install.command,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+            env=process_environment,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        _fail("update", str(exc), 1, json_output)
+        return
+
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or f"Exited with status {completed.returncode}."
+        _fail("update", detail[-2000:], 1, json_output)
+        return
+
+    try:
+        current = _installed_version()
+        if _is_newer(latest, current):
+            raise RuntimeError(
+                f"The package manager completed, but Tavily CLI is still {current}; latest is {latest}. "
+                "The installation may be pinned."
+            )
+    except Exception as exc:
+        _fail("verify", str(exc), 1, json_output)
+        return
+    result = _result(
+        current=current,
+        latest=latest,
+        install=install,
+        updated=Version(current) != Version(__version__),
+    )
+    _print_result(result, json_output=json_output, check_only=False)
+
+
+def fetch_latest_version(*, client: httpx.Client | None = None) -> str:
+    """Return the latest stable Tavily CLI version published on PyPI."""
+    http = client or httpx.Client(timeout=10.0, follow_redirects=True)
+    close = client is None
+    try:
+        response = http.get(PYPI_URL)
+        response.raise_for_status()
+        data = response.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        raise RuntimeError("Could not check PyPI for Tavily CLI updates.") from exc
+    finally:
+        if close:
+            http.close()
+
+    info = data.get("info") if isinstance(data, dict) else None
+    latest = info.get("version") if isinstance(info, dict) else None
+    if not isinstance(latest, str):
+        raise RuntimeError("PyPI returned an invalid Tavily CLI release response.")
+    try:
+        Version(latest)
+    except InvalidVersion as exc:
+        raise RuntimeError("PyPI returned an invalid Tavily CLI version.") from exc
+    return latest
+
+
+def detect_install(
+    *,
+    distribution: metadata.Distribution | None = None,
+    executable: Path | None = None,
+    prefix: Path | None = None,
+    which: Callable[[str], str | None] = shutil.which,
+) -> InstallInfo:
+    """Detect the manager for the active package without changing the environment."""
+    dist = distribution or metadata.distribution(PACKAGE_NAME)
+    # Keep the venv executable path intact. Resolving its symlink can point pip
+    # at the base interpreter and update the wrong environment.
+    python = (executable or Path(sys.executable)).absolute()
+    environment = (prefix or Path(sys.prefix)).resolve()
+
+    if _is_source_install(dist):
+        return InstallInfo("source", None)
+
+    path = f"{python.as_posix()}:{environment.as_posix()}".lower()
+    if (environment / "pipx_metadata.json").is_file() or "/pipx/venvs/" in path:
+        pipx = which("pipx")
+        manager_environment: tuple[tuple[str, str], ...] = ()
+        if environment.parent.name.lower() == "venvs":
+            manager_environment = (("PIPX_HOME", str(environment.parent.parent)),)
+        return InstallInfo("pipx", (pipx, "upgrade", PACKAGE_NAME) if pipx else None, manager_environment)
+
+    if (environment / "uv-receipt.toml").is_file() or "/uv/tools/" in path:
+        uv = which("uv")
+        manager_environment = (("UV_TOOL_DIR", str(environment.parent)),)
+        return InstallInfo("uv", (uv, "tool", "upgrade", PACKAGE_NAME) if uv else None, manager_environment)
+
+    installer = (dist.read_text("INSTALLER") or "").strip().lower()
+    if installer == "uv":
+        uv = which("uv")
+        command = (uv, "pip", "install", "--python", str(python), "--upgrade", PACKAGE_NAME) if uv else None
+        return InstallInfo("uv", command)
+    if installer in {"pip", "pip3"}:
+        command = [str(python), "-m", "pip", "install", "--upgrade", PACKAGE_NAME]
+        if _is_user_install(dist):
+            command.insert(-2, "--user")
+        return InstallInfo("pip", tuple(command))
+    return InstallInfo("unknown", None)
+
+
+def _is_source_install(distribution: metadata.Distribution) -> bool:
+    raw = distribution.read_text("direct_url.json")
+    if not raw:
+        return False
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return False
+    if not isinstance(data, dict):
+        return False
+    # PyPI installs do not have direct_url.json. Editable, VCS, local archive,
+    # and other direct-URL installs do; preserve that provenance instead of
+    # silently replacing it with a registry release.
+    return isinstance(data.get("url"), str)
+
+
+def _is_user_install(distribution: metadata.Distribution) -> bool:
+    try:
+        package_root = Path(distribution.locate_file("")).resolve()
+        user_root = Path(site.getusersitepackages()).resolve()
+        return package_root == user_root or user_root in package_root.parents
+    except (AttributeError, OSError, RuntimeError):
+        return False
+
+
+def _is_newer(candidate: str, current: str) -> bool:
+    try:
+        return Version(candidate) > Version(current)
+    except InvalidVersion as exc:
+        raise RuntimeError("The installed Tavily CLI version is invalid.") from exc
+
+
+def _installed_version() -> str:
+    return metadata.version(PACKAGE_NAME)
+
+
+def _unsupported_install_message(method: str) -> str:
+    if method == "source":
+        return "This is a source or direct-URL installation. Update it from its original source."
+    if method in {"uv", "pipx"}:
+        return f"This installation is managed by {method}, but {method} is not available on PATH."
+    return "Could not determine how Tavily CLI was installed. Update it with the original package manager."
+
+
+def _result(*, current: str, latest: str, install: InstallInfo, updated: bool) -> dict[str, object]:
+    return {
+        "ok": True,
+        "current_version": current,
+        "latest_version": latest,
+        "update_available": _is_newer(latest, current),
+        "install_method": install.method,
+        "updated": updated,
+    }
+
+
+def _fail(stage: str, message: str, exit_code: int, json_output: bool) -> None:
+    safe_message = sanitize_control(message)
+    if json_output:
+        click.echo(json.dumps({"ok": False, "error": {"stage": stage, "message": safe_message}}, sort_keys=True))
+    else:
+        from rich.markup import escape
+
+        from tavily_cli.theme import err_console
+
+        err_console.print(f"  [#FAA2FB]> Update failed:[/#FAA2FB] {escape(safe_message)}")
+    raise click.exceptions.Exit(exit_code)
+
+
+def _print_result(result: dict[str, object], *, json_output: bool, check_only: bool) -> None:
+    if json_output:
+        click.echo(json.dumps(result, sort_keys=True))
+        return
+
+    current = result["current_version"]
+    latest = result["latest_version"]
+    if result["updated"]:
+        click.echo(f"Updated Tavily CLI: {__version__} -> {current}")
+    elif result["update_available"]:
+        click.echo(f"Tavily CLI update available: {current} -> {latest}")
+        if check_only:
+            click.echo("Run `tvly update` to install it.")
+    else:
+        click.echo(f"Tavily CLI {current} is up to date.")

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -39,6 +39,17 @@ class FakeDistribution:
         return self.root / path
 
 
+def expose_entrypoint(environment: Path, bin_dir: Path, *, name: str = "tvly") -> Path:
+    target = environment / "bin" / "tvly"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("")
+    target.chmod(0o755)
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    entrypoint = bin_dir / name
+    entrypoint.symlink_to(target)
+    return entrypoint
+
+
 def test_fetch_latest_version_from_pypi() -> None:
     transport = httpx.MockTransport(
         lambda request: httpx.Response(200, json={"info": {"version": "1.2.3"}}, request=request)
@@ -61,7 +72,10 @@ def test_fetch_latest_version_rejects_invalid_response() -> None:
             Path("/home/user/.local/share/uv/tools/tavily-cli/bin/python"),
             "uv",
             ("/usr/bin/uv", "tool", "upgrade", "tavily-cli"),
-            (("UV_TOOL_DIR", str(Path("/home/user/.local/share/uv/tools").resolve())),),
+            (
+                ("UV_TOOL_DIR", str(Path("/home/user/.local/share/uv/tools").resolve())),
+                ("UV_TOOL_BIN_DIR", "/home/user/.local/bin"),
+            ),
         ),
         (
             FakeDistribution(installer="uv"),
@@ -83,7 +97,10 @@ def test_fetch_latest_version_rejects_invalid_response() -> None:
             Path("/home/user/.local/pipx/venvs/tavily-cli/bin/python"),
             "pipx",
             ("/usr/bin/pipx", "upgrade", "tavily-cli"),
-            (("PIPX_HOME", str(Path("/home/user/.local/pipx").resolve())),),
+            (
+                ("PIPX_HOME", str(Path("/home/user/.local/pipx").resolve())),
+                ("PIPX_BIN_DIR", "/home/user/.local/bin"),
+            ),
         ),
         (
             FakeDistribution(),
@@ -105,6 +122,10 @@ def test_detect_install_managers(
         distribution=distribution,  # type: ignore[arg-type]
         executable=executable,
         prefix=executable.parent.parent,
+        process_environment={
+            "PIPX_BIN_DIR": "/home/user/.local/bin",
+            "UV_TOOL_BIN_DIR": "/home/user/.local/bin",
+        },
         which=lambda command: f"/usr/bin/{command}",
     )
 
@@ -176,18 +197,22 @@ def test_detect_uv_receipt_preserves_custom_tool_dir(tmp_path: Path) -> None:
     environment = tool_dir / "tavily-cli"
     environment.mkdir(parents=True)
     (environment / "uv-receipt.toml").write_text("")
+    bin_dir = tmp_path / "custom-bin"
+    entrypoint = expose_entrypoint(environment, bin_dir)
 
     detected = detect_install(
         distribution=FakeDistribution(),  # type: ignore[arg-type]
         executable=environment / "bin" / "python",
         prefix=environment,
+        entrypoint=entrypoint,
+        process_environment={},
         which=lambda command: f"/tools/{command}",
     )
 
     assert detected == InstallInfo(
         "uv",
         ("/tools/uv", "tool", "upgrade", "tavily-cli"),
-        (("UV_TOOL_DIR", str(tool_dir)),),
+        (("UV_TOOL_DIR", str(tool_dir)), ("UV_TOOL_BIN_DIR", str(bin_dir))),
     )
 
 
@@ -196,18 +221,48 @@ def test_detect_pipx_receipt_preserves_custom_home(tmp_path: Path) -> None:
     environment = pipx_home / "venvs" / "tavily-cli"
     environment.mkdir(parents=True)
     (environment / "pipx_metadata.json").write_text("")
+    bin_dir = tmp_path / "custom-bin"
+    entrypoint = expose_entrypoint(environment, bin_dir)
 
     detected = detect_install(
         distribution=FakeDistribution(),  # type: ignore[arg-type]
         executable=environment / "bin" / "python",
         prefix=environment,
+        entrypoint=entrypoint,
+        process_environment={},
         which=lambda command: f"/tools/{command}",
     )
 
     assert detected == InstallInfo(
         "pipx",
         ("/tools/pipx", "upgrade", "tavily-cli"),
-        (("PIPX_HOME", str(pipx_home)),),
+        (("PIPX_HOME", str(pipx_home)), ("PIPX_BIN_DIR", str(bin_dir))),
+    )
+
+
+def test_detect_pipx_recovers_invoked_entrypoint_from_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pipx_home = tmp_path / "custom-pipx"
+    environment = pipx_home / "venvs" / "tavily-cli"
+    environment.mkdir(parents=True)
+    (environment / "pipx_metadata.json").write_text("")
+    bin_dir = tmp_path / "custom-bin"
+    expose_entrypoint(environment, bin_dir)
+    monkeypatch.setenv("PATH", str(bin_dir))
+    monkeypatch.setattr(update_module.sys, "argv", ["tvly"])
+
+    detected = detect_install(
+        distribution=FakeDistribution(),  # type: ignore[arg-type]
+        executable=environment / "bin" / "python",
+        prefix=environment,
+        process_environment={},
+        which=lambda command: f"/tools/{command}",
+    )
+
+    assert detected.environment == (
+        ("PIPX_HOME", str(pipx_home)),
+        ("PIPX_BIN_DIR", str(bin_dir)),
     )
 
 
@@ -216,19 +271,57 @@ def test_detect_pipx_suffixed_install_uses_active_environment_name(tmp_path: Pat
     environment = pipx_home / "venvs" / "tavily-cli-old"
     environment.mkdir(parents=True)
     (environment / "pipx_metadata.json").write_text("")
+    bin_dir = tmp_path / "custom-bin"
+    entrypoint = expose_entrypoint(environment, bin_dir, name="tvly-old")
 
     detected = detect_install(
         distribution=FakeDistribution(),  # type: ignore[arg-type]
         executable=environment / "bin" / "python",
         prefix=environment,
+        entrypoint=entrypoint,
+        process_environment={},
         which=lambda command: f"/tools/{command}",
     )
 
     assert detected == InstallInfo(
         "pipx",
         ("/tools/pipx", "upgrade", "tavily-cli-old"),
-        (("PIPX_HOME", str(pipx_home)),),
+        (("PIPX_HOME", str(pipx_home)), ("PIPX_BIN_DIR", str(bin_dir))),
     )
+
+
+@pytest.mark.parametrize(
+    ("environment_parts", "receipt", "variable"),
+    [
+        (("custom-pipx", "venvs", "tavily-cli"), "pipx_metadata.json", "PIPX_BIN_DIR"),
+        (("custom-uv", "tavily-cli"), "uv-receipt.toml", "UV_TOOL_BIN_DIR"),
+    ],
+)
+def test_detect_manager_refuses_unverified_binary_directory(
+    tmp_path: Path,
+    environment_parts: tuple[str, ...],
+    receipt: str,
+    variable: str,
+) -> None:
+    environment = tmp_path.joinpath(*environment_parts)
+    environment.mkdir(parents=True)
+    (environment / receipt).write_text("")
+    internal_entrypoint = environment / "bin" / "tvly"
+    internal_entrypoint.parent.mkdir()
+    internal_entrypoint.write_text("")
+
+    detected = detect_install(
+        distribution=FakeDistribution(),  # type: ignore[arg-type]
+        executable=environment / "bin" / "python",
+        prefix=environment,
+        entrypoint=internal_entrypoint,
+        process_environment={},
+        which=lambda command: f"/tools/{command}",
+    )
+
+    assert detected.command is None
+    assert detected.blocked_reason is not None
+    assert variable in detected.blocked_reason
 
 
 def test_update_check_json_is_read_only(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -252,6 +345,21 @@ def test_update_check_json_is_read_only(monkeypatch: pytest.MonkeyPatch) -> None
         "update_available": True,
         "updated": False,
     }
+
+
+def test_update_check_does_not_require_manager_binary_directory(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_module, "__version__", "1.0.0")
+    monkeypatch.setattr(update_module, "fetch_latest_version", lambda: "1.1.0")
+    monkeypatch.setattr(
+        update_module,
+        "detect_install",
+        lambda: InstallInfo("pipx", None, blocked_reason="Could not safely determine PIPX_BIN_DIR."),
+    )
+
+    result = CliRunner().invoke(cli, ["update", "--check", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["update_available"] is True
 
 
 def test_update_check_failure_is_structured(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -311,7 +419,11 @@ def test_update_runs_detected_manager_and_verifies_version(monkeypatch: pytest.M
     monkeypatch.setattr(
         update_module,
         "detect_install",
-        lambda: InstallInfo("pipx", command, (("PIPX_HOME", "/custom/pipx"),)),
+        lambda: InstallInfo(
+            "pipx",
+            command,
+            (("PIPX_HOME", "/custom/pipx"), ("PIPX_BIN_DIR", "/custom/bin")),
+        ),
     )
     monkeypatch.setattr(update_module, "_installed_version", lambda: "1.1.0")
 
@@ -329,6 +441,7 @@ def test_update_runs_detected_manager_and_verifies_version(monkeypatch: pytest.M
     assert result.exit_code == 0
     assert calls == [command]
     assert environments[0]["PIPX_HOME"] == "/custom/pipx"
+    assert environments[0]["PIPX_BIN_DIR"] == "/custom/bin"
     assert environments[0]["PATH"] == os.environ["PATH"]
     assert json.loads(result.stdout) == {
         "current_version": "1.1.0",
@@ -351,6 +464,21 @@ def test_update_refuses_editable_install(monkeypatch: pytest.MonkeyPatch) -> Non
     output = json.loads(result.stdout)
     assert output["ok"] is False
     assert output["error"]["stage"] == "install_method"
+
+
+def test_update_reports_unsafe_manager_binary_directory(monkeypatch: pytest.MonkeyPatch) -> None:
+    reason = "Could not safely determine PIPX_BIN_DIR."
+    monkeypatch.setattr(update_module, "__version__", "1.0.0")
+    monkeypatch.setattr(update_module, "fetch_latest_version", lambda: "1.1.0")
+    monkeypatch.setattr(update_module, "detect_install", lambda: InstallInfo("pipx", None, blocked_reason=reason))
+
+    result = CliRunner().invoke(cli, ["update", "--json"])
+
+    assert result.exit_code == 1
+    assert json.loads(result.stdout) == {
+        "error": {"message": reason, "stage": "install_method"},
+        "ok": False,
+    }
 
 
 def test_update_failure_is_structured_and_sanitized(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -324,6 +324,46 @@ def test_detect_manager_refuses_unverified_binary_directory(
     assert variable in detected.blocked_reason
 
 
+@pytest.mark.parametrize(
+    ("environment", "process_environment"),
+    [
+        (Path("/home/user/.cache/uv/archive-v0/cache-id"), {}),
+        (
+            Path("/tmp/custom-uv-cache/future-layout/cache-id"),
+            {"UV_CACHE_DIR": "/tmp/custom-uv-cache"},
+        ),
+    ],
+)
+def test_detect_uvx_cache_environment_refuses_mutation(
+    environment: Path, process_environment: dict[str, str]
+) -> None:
+    detected = detect_install(
+        distribution=FakeDistribution(installer="uv"),  # type: ignore[arg-type]
+        executable=environment / "bin" / "python",
+        prefix=environment,
+        process_environment=process_environment,
+        which=lambda command: f"/tools/{command}",
+    )
+
+    assert detected == InstallInfo("uvx", None)
+
+
+def test_detect_uvx_takes_precedence_over_direct_url_install() -> None:
+    environment = Path("/home/user/.cache/uv/archive-v0/cache-id")
+    detected = detect_install(
+        distribution=FakeDistribution(
+            installer="uv",
+            direct_url=json.dumps({"url": "https://example.com/tavily-cli.whl"}),
+        ),  # type: ignore[arg-type]
+        executable=environment / "bin" / "python",
+        prefix=environment,
+        process_environment={},
+        which=lambda command: f"/tools/{command}",
+    )
+
+    assert detected == InstallInfo("uvx", None)
+
+
 def test_update_check_json_is_read_only(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(update_module, "__version__", "1.0.0")
     monkeypatch.setattr(update_module, "fetch_latest_version", lambda: "1.1.0")
@@ -479,6 +519,24 @@ def test_update_reports_unsafe_manager_binary_directory(monkeypatch: pytest.Monk
         "error": {"message": reason, "stage": "install_method"},
         "ok": False,
     }
+
+
+def test_update_refuses_uvx_cache_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_module, "__version__", "1.0.0")
+    monkeypatch.setattr(update_module, "fetch_latest_version", lambda: "1.1.0")
+    monkeypatch.setattr(update_module, "detect_install", lambda: InstallInfo("uvx", None))
+    monkeypatch.setattr(
+        update_module.subprocess,
+        "run",
+        lambda *args, **kwargs: pytest.fail("uvx cache environments must not be mutated"),
+    )
+
+    result = CliRunner().invoke(cli, ["update", "--json"])
+
+    assert result.exit_code == 1
+    output = json.loads(result.stdout)
+    assert output["error"]["stage"] == "install_method"
+    assert "rerun uvx" in output["error"]["message"]
 
 
 def test_update_failure_is_structured_and_sanitized(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -211,6 +211,26 @@ def test_detect_pipx_receipt_preserves_custom_home(tmp_path: Path) -> None:
     )
 
 
+def test_detect_pipx_suffixed_install_uses_active_environment_name(tmp_path: Path) -> None:
+    pipx_home = tmp_path / "custom-pipx"
+    environment = pipx_home / "venvs" / "tavily-cli-old"
+    environment.mkdir(parents=True)
+    (environment / "pipx_metadata.json").write_text("")
+
+    detected = detect_install(
+        distribution=FakeDistribution(),  # type: ignore[arg-type]
+        executable=environment / "bin" / "python",
+        prefix=environment,
+        which=lambda command: f"/tools/{command}",
+    )
+
+    assert detected == InstallInfo(
+        "pipx",
+        ("/tools/pipx", "upgrade", "tavily-cli-old"),
+        (("PIPX_HOME", str(pipx_home)),),
+    )
+
+
 def test_update_check_json_is_read_only(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(update_module, "__version__", "1.0.0")
     monkeypatch.setattr(update_module, "fetch_latest_version", lambda: "1.1.0")

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,369 @@
+"""Tests for Tavily CLI update checks and installer detection."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from tavily_cli.cli import cli
+from tavily_cli.commands import update as update_module
+from tavily_cli.commands.update import InstallInfo, detect_install, fetch_latest_version
+
+
+class FakeDistribution:
+    def __init__(
+        self,
+        *,
+        installer: str = "pip",
+        direct_url: str | None = None,
+        root: Path = Path("/opt/tavily"),
+    ) -> None:
+        self.installer = installer
+        self.direct_url = direct_url
+        self.root = root
+
+    def read_text(self, filename: str) -> str | None:
+        if filename == "INSTALLER":
+            return self.installer
+        if filename == "direct_url.json":
+            return self.direct_url
+        return None
+
+    def locate_file(self, path: str) -> Path:
+        return self.root / path
+
+
+def test_fetch_latest_version_from_pypi() -> None:
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(200, json={"info": {"version": "1.2.3"}}, request=request)
+    )
+    with httpx.Client(transport=transport) as client:
+        assert fetch_latest_version(client=client) == "1.2.3"
+
+
+def test_fetch_latest_version_rejects_invalid_response() -> None:
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, json={"info": {}}, request=request))
+    with httpx.Client(transport=transport) as client, pytest.raises(RuntimeError, match="invalid.*release response"):
+        fetch_latest_version(client=client)
+
+
+@pytest.mark.parametrize(
+    ("distribution", "executable", "expected_method", "expected_command", "expected_environment"),
+    [
+        (
+            FakeDistribution(installer="uv"),
+            Path("/home/user/.local/share/uv/tools/tavily-cli/bin/python"),
+            "uv",
+            ("/usr/bin/uv", "tool", "upgrade", "tavily-cli"),
+            (("UV_TOOL_DIR", str(Path("/home/user/.local/share/uv/tools").resolve())),),
+        ),
+        (
+            FakeDistribution(installer="uv"),
+            Path("/workspace/.venv/bin/python"),
+            "uv",
+            (
+                "/usr/bin/uv",
+                "pip",
+                "install",
+                "--python",
+                "/workspace/.venv/bin/python",
+                "--upgrade",
+                "tavily-cli",
+            ),
+            (),
+        ),
+        (
+            FakeDistribution(),
+            Path("/home/user/.local/pipx/venvs/tavily-cli/bin/python"),
+            "pipx",
+            ("/usr/bin/pipx", "upgrade", "tavily-cli"),
+            (("PIPX_HOME", str(Path("/home/user/.local/pipx").resolve())),),
+        ),
+        (
+            FakeDistribution(),
+            Path("/opt/tavily/bin/python"),
+            "pip",
+            ("/opt/tavily/bin/python", "-m", "pip", "install", "--upgrade", "tavily-cli"),
+            (),
+        ),
+    ],
+)
+def test_detect_install_managers(
+    distribution: FakeDistribution,
+    executable: Path,
+    expected_method: str,
+    expected_command: tuple[str, ...],
+    expected_environment: tuple[tuple[str, str], ...],
+) -> None:
+    detected = detect_install(
+        distribution=distribution,  # type: ignore[arg-type]
+        executable=executable,
+        prefix=executable.parent.parent,
+        which=lambda command: f"/usr/bin/{command}",
+    )
+
+    assert detected == InstallInfo(expected_method, expected_command, expected_environment)
+
+
+def test_detect_pip_install_preserves_virtualenv_executable(tmp_path: Path) -> None:
+    environment = tmp_path / "venv"
+    executable = environment / "bin" / "python"
+    executable.parent.mkdir(parents=True)
+    executable.symlink_to(Path("/usr/bin/python3"))
+
+    detected = detect_install(
+        distribution=FakeDistribution(),  # type: ignore[arg-type]
+        executable=executable,
+        prefix=environment,
+    )
+
+    assert detected == InstallInfo(
+        "pip",
+        (str(executable), "-m", "pip", "install", "--upgrade", "tavily-cli"),
+    )
+
+
+def test_detect_editable_install_refuses_self_update() -> None:
+    distribution = FakeDistribution(
+        direct_url=json.dumps({"url": "file:///workspace/tavily-cli", "dir_info": {"editable": True}})
+    )
+
+    detected = detect_install(
+        distribution=distribution,  # type: ignore[arg-type]
+        executable=Path("/workspace/.venv/bin/python"),
+        prefix=Path("/workspace/.venv"),
+    )
+
+    assert detected == InstallInfo("source", None)
+
+
+def test_detect_vcs_install_refuses_self_update() -> None:
+    distribution = FakeDistribution(
+        direct_url=json.dumps({"url": "https://github.com/tavily-ai/tavily-cli.git", "vcs_info": {"vcs": "git"}})
+    )
+
+    detected = detect_install(
+        distribution=distribution,  # type: ignore[arg-type]
+        executable=Path("/workspace/.venv/bin/python"),
+        prefix=Path("/workspace/.venv"),
+    )
+
+    assert detected == InstallInfo("source", None)
+
+
+def test_detect_local_wheel_install_refuses_self_update() -> None:
+    distribution = FakeDistribution(
+        direct_url=json.dumps({"url": "file:///tmp/tavily_cli.whl", "archive_info": {}})
+    )
+
+    detected = detect_install(
+        distribution=distribution,  # type: ignore[arg-type]
+        executable=Path("/tools/tavily-cli/bin/python"),
+        prefix=Path("/tools/tavily-cli"),
+    )
+
+    assert detected == InstallInfo("source", None)
+
+
+def test_detect_uv_receipt_preserves_custom_tool_dir(tmp_path: Path) -> None:
+    tool_dir = tmp_path / "custom-uv"
+    environment = tool_dir / "tavily-cli"
+    environment.mkdir(parents=True)
+    (environment / "uv-receipt.toml").write_text("")
+
+    detected = detect_install(
+        distribution=FakeDistribution(),  # type: ignore[arg-type]
+        executable=environment / "bin" / "python",
+        prefix=environment,
+        which=lambda command: f"/tools/{command}",
+    )
+
+    assert detected == InstallInfo(
+        "uv",
+        ("/tools/uv", "tool", "upgrade", "tavily-cli"),
+        (("UV_TOOL_DIR", str(tool_dir)),),
+    )
+
+
+def test_detect_pipx_receipt_preserves_custom_home(tmp_path: Path) -> None:
+    pipx_home = tmp_path / "custom-pipx"
+    environment = pipx_home / "venvs" / "tavily-cli"
+    environment.mkdir(parents=True)
+    (environment / "pipx_metadata.json").write_text("")
+
+    detected = detect_install(
+        distribution=FakeDistribution(),  # type: ignore[arg-type]
+        executable=environment / "bin" / "python",
+        prefix=environment,
+        which=lambda command: f"/tools/{command}",
+    )
+
+    assert detected == InstallInfo(
+        "pipx",
+        ("/tools/pipx", "upgrade", "tavily-cli"),
+        (("PIPX_HOME", str(pipx_home)),),
+    )
+
+
+def test_update_check_json_is_read_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_module, "__version__", "1.0.0")
+    monkeypatch.setattr(update_module, "fetch_latest_version", lambda: "1.1.0")
+    monkeypatch.setattr(update_module, "detect_install", lambda: InstallInfo("uv", ("uv", "tool", "upgrade")))
+    monkeypatch.setattr(
+        update_module.subprocess,
+        "run",
+        lambda *args, **kwargs: pytest.fail("--check must not run an update command"),
+    )
+
+    result = CliRunner().invoke(cli, ["update", "--check", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {
+        "current_version": "1.0.0",
+        "install_method": "uv",
+        "latest_version": "1.1.0",
+        "ok": True,
+        "update_available": True,
+        "updated": False,
+    }
+
+
+def test_update_check_failure_is_structured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        update_module,
+        "fetch_latest_version",
+        lambda: (_ for _ in ()).throw(RuntimeError("PyPI unavailable")),
+    )
+
+    result = CliRunner().invoke(cli, ["update", "--check", "--json"])
+
+    assert result.exit_code == 4
+    assert json.loads(result.stdout) == {
+        "error": {"message": "PyPI unavailable", "stage": "check"},
+        "ok": False,
+    }
+
+
+def test_install_detection_failure_is_not_reported_as_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_module, "fetch_latest_version", lambda: "1.1.0")
+    monkeypatch.setattr(
+        update_module,
+        "detect_install",
+        lambda: (_ for _ in ()).throw(RuntimeError("Package metadata unavailable")),
+    )
+
+    result = CliRunner().invoke(cli, ["update", "--check", "--json"])
+
+    assert result.exit_code == 1
+    output = json.loads(result.stdout)
+    assert output["error"] == {"message": "Package metadata unavailable", "stage": "install_method"}
+
+
+def test_update_does_nothing_when_current(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_module, "__version__", "1.1.0")
+    monkeypatch.setattr(update_module, "fetch_latest_version", lambda: "1.1.0")
+    monkeypatch.setattr(update_module, "detect_install", lambda: InstallInfo("pip", ("pip", "install")))
+    monkeypatch.setattr(
+        update_module.subprocess,
+        "run",
+        lambda *args, **kwargs: pytest.fail("An up-to-date installation must not run an update command"),
+    )
+
+    result = CliRunner().invoke(cli, ["update", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["update_available"] is False
+
+
+def test_update_runs_detected_manager_and_verifies_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    command = ("pipx", "upgrade", "tavily-cli")
+    calls: list[tuple[str, ...]] = []
+    environments: list[dict[str, str]] = []
+    monkeypatch.delenv("PIPX_HOME", raising=False)
+    monkeypatch.setattr(update_module, "__version__", "1.0.0")
+    monkeypatch.setattr(update_module, "fetch_latest_version", lambda: "1.1.0")
+    monkeypatch.setattr(
+        update_module,
+        "detect_install",
+        lambda: InstallInfo("pipx", command, (("PIPX_HOME", "/custom/pipx"),)),
+    )
+    monkeypatch.setattr(update_module, "_installed_version", lambda: "1.1.0")
+
+    def run(args: tuple[str, ...], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        environment = kwargs["env"]
+        assert isinstance(environment, dict)
+        environments.append(environment)
+        return subprocess.CompletedProcess(args, 0, stdout="updated", stderr="")
+
+    monkeypatch.setattr(update_module.subprocess, "run", run)
+
+    result = CliRunner().invoke(cli, ["update", "--json"])
+
+    assert result.exit_code == 0
+    assert calls == [command]
+    assert environments[0]["PIPX_HOME"] == "/custom/pipx"
+    assert environments[0]["PATH"] == os.environ["PATH"]
+    assert json.loads(result.stdout) == {
+        "current_version": "1.1.0",
+        "install_method": "pipx",
+        "latest_version": "1.1.0",
+        "ok": True,
+        "update_available": False,
+        "updated": True,
+    }
+
+
+def test_update_refuses_editable_install(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_module, "__version__", "1.0.0")
+    monkeypatch.setattr(update_module, "fetch_latest_version", lambda: "1.1.0")
+    monkeypatch.setattr(update_module, "detect_install", lambda: InstallInfo("source", None))
+
+    result = CliRunner().invoke(cli, ["update", "--json"])
+
+    assert result.exit_code == 1
+    output = json.loads(result.stdout)
+    assert output["ok"] is False
+    assert output["error"]["stage"] == "install_method"
+
+
+def test_update_failure_is_structured_and_sanitized(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_module, "__version__", "1.0.0")
+    monkeypatch.setattr(update_module, "fetch_latest_version", lambda: "1.1.0")
+    monkeypatch.setattr(update_module, "detect_install", lambda: InstallInfo("uv", ("uv", "tool", "upgrade")))
+    monkeypatch.setattr(
+        update_module.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 2, stdout="", stderr="failed\x1b[2J"),
+    )
+
+    result = CliRunner().invoke(cli, ["update", "--json"])
+
+    assert result.exit_code == 1
+    output = json.loads(result.stdout)
+    assert output == {"error": {"message": "failed[2J", "stage": "update"}, "ok": False}
+
+
+def test_update_verifies_package_manager_changed_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_module, "__version__", "1.0.0")
+    monkeypatch.setattr(update_module, "fetch_latest_version", lambda: "1.1.0")
+    monkeypatch.setattr(update_module, "detect_install", lambda: InstallInfo("pipx", ("pipx", "upgrade")))
+    monkeypatch.setattr(update_module, "_installed_version", lambda: "1.0.0")
+    monkeypatch.setattr(
+        update_module.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, stdout="", stderr=""),
+    )
+
+    result = CliRunner().invoke(cli, ["update", "--json"])
+
+    assert result.exit_code == 1
+    output = json.loads(result.stdout)
+    assert output["error"]["stage"] == "verify"
+    assert "may be pinned" in output["error"]["message"]


### PR DESCRIPTION
## Summary

- Adds `tvly update` and read-only `tvly update --check`
- Detects uv, pipx, and pip installations
- Preserves custom uv and pipx installation locations
- Provides stable JSON output and post-update verification
- Refuses to replace source or direct-URL installations

## Testing

- 20 automated tests passing
- Python 3.10 compilation passing
- Wheel build and installation verified
- Isolated uv, pip, and pipx updates tested from 0.1.5 to 0.1.6
- Custom pipx update verified with `PIPX_HOME` unset