### PR TITLE
fix: stop packaging untracked working-tree files into the sdist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ env/
 # OS
 .DS_Store
 Thumbs.db
+
+# Local agent/editor state
+.claude/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,16 @@ dev = [
 [tool.hatch.build.targets.wheel]
 packages = ["tavily_cli"]
 
+[tool.hatch.build.targets.sdist]
+only-include = [
+    "tavily_cli",
+    "tests",
+    "install.sh",
+    "pyproject.toml",
+    "README.md",
+    "LICENSE",
+]
+
 [tool.ruff]
 line-length = 120
 target-version = "py310"


### PR DESCRIPTION
## Summary

`pyproject.toml` declared a wheel build target but no sdist target. Hatchling therefore fell back to sweeping the entire project root, excluding only what `.gitignore` matched — so **every untracked file in the maintainer's working tree was packaged into the sdist**.

This pins an explicit `only-include` list for the sdist and adds `.claude/` to `.gitignore`.

## Evidence

Found while auditing the 0.1.7 release artifacts before publishing. A locally built `tavily_cli-0.1.7.tar.gz` contained:

```
.claude/settings.local.json     # a developer's local agent permission allowlist
```

Planting decoys and rebuilding confirmed the general case — all three shipped:

| Decoy | sdist | wheel |
|---|---|---|
| `.env.decoy` | shipped | — |
| `scratch_decoy/notes.txt` | shipped | — |
| `tavily_cli/decoy_untracked.py` | shipped | shipped |

`.gitignore` was doing the filtering, which is why `dist/`, `.venv/`, and `__pycache__` were correctly excluded — but it never covered `.claude/`, `.env.*`, or arbitrary scratch directories.

## Blast radius

**None so far.** I pulled the published sdists from PyPI and inspected them:

- `tavily-cli` 0.1.5 — clean
- `tavily-cli` 0.1.6 — clean

Nothing has leaked. This closes the hole before 0.1.7 goes out.

## Verification

Rebuilt with the same three decoys still present in the working tree:

- sdist: 30 paths, exactly `tavily_cli/` + `tests/` + `install.sh` / `pyproject.toml` / `README.md` / `LICENSE` / `.gitignore` / `PKG-INFO`
- wheel: unchanged, 21 modules + `dist-info`
- `twine check` PASSED on both
- wheel installs and runs on Python 3.10 and 3.13
- 91 tests pass

## Known limitation

A stray file dropped *inside* `tavily_cli/` is still picked up, because inclusion is directory-based and no config closes that. Releases should keep being built from a clean tree:

```bash
git status --porcelain --untracked-files=all   # must be empty
rm -rf dist && uv build
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)