### PR TITLE
fix: upgrade existing uv and pipx installs in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -94,11 +94,11 @@ main() {
     # Install via uv (fastest) — no system Python required
     if command -v uv >/dev/null 2>&1; then
         info "Installing ${PACKAGE_NAME} with uv..."
-        if ! uv tool list 2>/dev/null | grep -q "^${PACKAGE_NAME} "; then
-            FRESH_INSTALL=1
-        fi
-        if ! uv tool install "$PACKAGE_NAME"; then
+        if uv tool list 2>/dev/null | grep -q "^${PACKAGE_NAME} "; then
             uv tool upgrade "$PACKAGE_NAME"
+        else
+            FRESH_INSTALL=1
+            uv tool install "$PACKAGE_NAME"
         fi
     else
         # Find Python (needed for pipx / pip)

--- a/install.sh
+++ b/install.sh
@@ -88,60 +88,96 @@ run_init_handoff() {
     warn "Guided setup did not complete. The CLI is installed; run 'tvly init' to try again."
 }
 
+require_python() {
+    if [ -z "${PYTHON:-}" ]; then
+        PYTHON=$(find_python) || error "Python ${MIN_PYTHON_MAJOR}.${MIN_PYTHON_MINOR}+ is required but not found.
+  Install it from https://www.python.org/downloads/ or install uv (https://docs.astral.sh/uv/) and try again."
+    fi
+}
+
+install_with_pip() {
+    require_python
+
+    py_version=$("$PYTHON" --version 2>&1)
+    info "Found $py_version"
+    info "Installing ${PACKAGE_NAME} with pip..."
+
+    if [ "$PIP_INSTALLED" != "1" ]; then
+        FRESH_INSTALL=1
+    fi
+
+    # Use --user only when outside a virtual environment
+    in_venv=$("$PYTHON" -c "import sys; print(int(sys.prefix != sys.base_prefix or hasattr(sys, 'real_prefix')))" 2>/dev/null) || in_venv=0
+    if [ "$in_venv" = "1" ]; then
+        "$PYTHON" -m pip install --upgrade "$PACKAGE_NAME"
+    else
+        "$PYTHON" -m pip install --user --upgrade "$PACKAGE_NAME"
+
+        # Warn if ~/.local/bin is not in PATH (common pip --user location)
+        user_bin=$("$PYTHON" -c "import site; print(site.getuserbase() + '/bin')" 2>/dev/null) || true
+        if [ -n "$user_bin" ] && ! echo "$PATH" | tr ':' '\n' | grep -qx "$user_bin"; then
+            warn "$user_bin is not in your PATH. Add it with:"
+            printf "  export PATH=\"%s:\$PATH\"\n\n" "$user_bin"
+        fi
+    fi
+}
+
 main() {
     printf "\n${BOLD}Tavily CLI Installer${RESET}\n\n"
 
-    # Install via uv (fastest) — no system Python required
+    # Preserve the package manager that already owns Tavily CLI. Only prefer uv
+    # for a fresh installation, after checking uv, pipx, and pip ownership.
+    UV_AVAILABLE=0
+    PIPX_AVAILABLE=0
+    UV_INSTALLED=0
+    PIPX_INSTALLED=0
+    PIP_INSTALLED=0
+    PYTHON=""
+
     if command -v uv >/dev/null 2>&1; then
-        info "Installing ${PACKAGE_NAME} with uv..."
+        UV_AVAILABLE=1
         if uv tool list 2>/dev/null | grep -q "^${PACKAGE_NAME} "; then
-            uv tool upgrade "$PACKAGE_NAME"
-        else
-            FRESH_INSTALL=1
-            uv tool install "$PACKAGE_NAME"
+            UV_INSTALLED=1
         fi
+    fi
+
+    if command -v pipx >/dev/null 2>&1; then
+        PIPX_AVAILABLE=1
+        if pipx list --short 2>/dev/null | grep -q "^${PACKAGE_NAME} "; then
+            PIPX_INSTALLED=1
+        fi
+    fi
+
+    PYTHON=$(find_python 2>/dev/null || true)
+    if [ -n "$PYTHON" ] && "$PYTHON" -m pip show "$PACKAGE_NAME" >/dev/null 2>&1; then
+        PIP_INSTALLED=1
+    fi
+
+    if [ "$UV_INSTALLED" = "1" ]; then
+        info "Installing ${PACKAGE_NAME} with uv..."
+        uv tool upgrade "$PACKAGE_NAME"
+    elif [ "$PIPX_INSTALLED" = "1" ]; then
+        info "Installing ${PACKAGE_NAME} with pipx..."
+        pipx upgrade "$PACKAGE_NAME"
+    elif [ "$PIP_INSTALLED" = "1" ]; then
+        install_with_pip
+    elif [ "$UV_AVAILABLE" = "1" ]; then
+        # uv is preferred for a fresh install and does not require system Python.
+        info "Installing ${PACKAGE_NAME} with uv..."
+        FRESH_INSTALL=1
+        uv tool install "$PACKAGE_NAME"
+    elif [ "$PIPX_AVAILABLE" = "1" ]; then
+        info "Installing ${PACKAGE_NAME} with pipx..."
+        FRESH_INSTALL=1
+        pipx install "$PACKAGE_NAME"
     else
-        # Find Python (needed for pipx / pip)
-        PYTHON=$(find_python) || error "Python ${MIN_PYTHON_MAJOR}.${MIN_PYTHON_MINOR}+ is required but not found.
-  Install it from https://www.python.org/downloads/ or install uv (https://docs.astral.sh/uv/) and try again."
-
-        py_version=$("$PYTHON" --version 2>&1)
-        info "Found $py_version"
-
-        if command -v pipx >/dev/null 2>&1; then
-            info "Installing ${PACKAGE_NAME} with pipx..."
-            if pipx list --short 2>/dev/null | grep -q "^${PACKAGE_NAME} "; then
-                pipx upgrade "$PACKAGE_NAME"
-            else
-                FRESH_INSTALL=1
-                pipx install "$PACKAGE_NAME"
-            fi
-        else
-            info "Installing ${PACKAGE_NAME} with pip..."
-            if ! "$PYTHON" -m pip show "$PACKAGE_NAME" >/dev/null 2>&1; then
-                FRESH_INSTALL=1
-            fi
-            # Use --user only when outside a virtual environment
-            in_venv=$("$PYTHON" -c "import sys; print(int(sys.prefix != sys.base_prefix or hasattr(sys, 'real_prefix')))" 2>/dev/null) || in_venv=0
-            if [ "$in_venv" = "1" ]; then
-                "$PYTHON" -m pip install --upgrade "$PACKAGE_NAME"
-            else
-                "$PYTHON" -m pip install --user --upgrade "$PACKAGE_NAME"
-
-                # Warn if ~/.local/bin is not in PATH (common pip --user location)
-                user_bin=$("$PYTHON" -c "import site; print(site.getusersitepackages().replace('/lib/python', '/bin').split('/lib/')[0] + '/bin')" 2>/dev/null) || true
-                if [ -n "$user_bin" ] && ! echo "$PATH" | tr ':' '\n' | grep -qx "$user_bin"; then
-                    warn "$user_bin is not in your PATH. Add it with:"
-                    printf "  export PATH=\"%s:\$PATH\"\n\n" "$user_bin"
-                fi
-            fi
-        fi
+        install_with_pip
     fi
 
     # Verify
     if command -v "$COMMAND_NAME" >/dev/null 2>&1; then
         installed_version=$("$COMMAND_NAME" --version 2>/dev/null || echo "unknown")
-        printf "\n${GREEN}${BOLD}Success!${RESET} ${PACKAGE_NAME} ${installed_version} is installed.\n"
+        printf "\n${GREEN}${BOLD}Success!${RESET} ${installed_version} is installed.\n"
     else
         printf "\n${GREEN}${BOLD}Installed!${RESET} You may need to restart your shell or add the install directory to your PATH.\n"
     fi

--- a/install.sh
+++ b/install.sh
@@ -110,11 +110,11 @@ main() {
 
         if command -v pipx >/dev/null 2>&1; then
             info "Installing ${PACKAGE_NAME} with pipx..."
-            if ! pipx list --short 2>/dev/null | grep -q "^${PACKAGE_NAME} "; then
-                FRESH_INSTALL=1
-            fi
-            if ! pipx install "$PACKAGE_NAME"; then
+            if pipx list --short 2>/dev/null | grep -q "^${PACKAGE_NAME} "; then
                 pipx upgrade "$PACKAGE_NAME"
+            else
+                FRESH_INSTALL=1
+                pipx install "$PACKAGE_NAME"
             fi
         else
             info "Installing ${PACKAGE_NAME} with pip..."

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -157,7 +157,7 @@ def test_init_failure_does_not_fail_successful_install(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(pty is None, reason="install.sh is a POSIX installer")
-def test_existing_uv_install_does_not_rerun_init(tmp_path: Path) -> None:
+def test_existing_uv_install_upgrades_without_rerunning_init(tmp_path: Path) -> None:
     env = _stub_environment(tmp_path, installed=True)
     env["DISPLAY"] = ":0"
 
@@ -166,7 +166,7 @@ def test_existing_uv_install_does_not_rerun_init(tmp_path: Path) -> None:
     assert status == 0
     assert (tmp_path / "calls.log").read_text().splitlines() == [
         "uv tool list",
-        "uv tool install tavily-cli",
+        "uv tool upgrade tavily-cli",
         "tvly --version",
     ]
     assert "Starting guided Tavily setup" not in output
@@ -174,18 +174,16 @@ def test_existing_uv_install_does_not_rerun_init(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(pty is None, reason="install.sh is a POSIX installer")
-def test_failed_uv_reinstall_falls_back_to_upgrade_without_init(tmp_path: Path) -> None:
-    env = _stub_environment(tmp_path, installed=True, install_exit=1)
+def test_failed_fresh_uv_install_exits_without_running_init(tmp_path: Path) -> None:
+    env = _stub_environment(tmp_path, install_exit=1)
     env["DISPLAY"] = ":0"
 
     status, output = _run_with_terminal(env)
 
-    assert status == 0
+    assert status == 1
     assert (tmp_path / "calls.log").read_text().splitlines() == [
         "uv tool list",
         "uv tool install tavily-cli",
-        "uv tool upgrade tavily-cli",
-        "tvly --version",
     ]
     assert "Starting guided Tavily setup" not in output
 

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -257,7 +257,7 @@ exit 0
 
 
 @pytest.mark.skipif(pty is None, reason="install.sh is a POSIX installer")
-def test_existing_pipx_install_does_not_rerun_init(tmp_path: Path) -> None:
+def test_existing_pipx_install_upgrades_without_rerunning_init(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log_file = tmp_path / "calls.log"
@@ -309,7 +309,6 @@ exit 0
     assert status == 0
     assert log_file.read_text().splitlines() == [
         "pipx list --short",
-        "pipx install tavily-cli",
         "pipx upgrade tavily-cli",
         "tvly --version",
     ]

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -33,6 +33,22 @@ def _stub_environment(
     bin_dir.mkdir()
     log_file = tmp_path / "calls.log"
     _write_executable(
+        bin_dir / "python3",
+        """#!/bin/sh
+if [ "$1" = "--version" ]; then
+    printf 'Python 3.11.0\\n'
+elif [ "$1" = "-c" ]; then
+    case "$2" in
+        *version_info*) printf '3.11\\n' ;;
+        *sys.prefix*) printf '1\\n' ;;
+    esac
+elif [ "$1 $2 $3" = "-m pip show" ]; then
+    exit 1
+fi
+exit 0
+""",
+    )
+    _write_executable(
         bin_dir / "uv",
         """#!/bin/sh
 printf 'uv %s\\n' "$*" >> "$TVLY_INSTALL_TEST_LOG"
@@ -141,6 +157,8 @@ def test_noninteractive_install_prints_init_without_running_it(tmp_path: Path) -
         "uv tool install tavily-cli",
         "tvly --version",
     ]
+    assert "Success! tavily-cli 0.1.8 is installed." in result.stdout
+    assert "tavily-cli tavily-cli" not in result.stdout
     assert "tvly init" in result.stdout
 
 
@@ -256,18 +274,79 @@ exit 0
     assert "python3 -m pip install --upgrade tavily-cli" in log_file.read_text().splitlines()
 
 
-@pytest.mark.skipif(pty is None, reason="install.sh is a POSIX installer")
-def test_existing_pipx_install_upgrades_without_rerunning_init(tmp_path: Path) -> None:
+def test_pip_user_install_warns_with_user_base_bin(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log_file = tmp_path / "calls.log"
     _write_executable(
         bin_dir / "python3",
         """#!/bin/sh
+printf 'python3 %s\\n' "$*" >> "$TVLY_INSTALL_TEST_LOG"
 if [ "$1" = "--version" ]; then
     printf 'Python 3.11.0\\n'
 elif [ "$1" = "-c" ]; then
-    printf '3.11\\n'
+    case "$2" in
+        *version_info*) printf '3.11\\n' ;;
+        *sys.prefix*) printf '0\\n' ;;
+        *getuserbase*) printf '/home/test-user/.local/bin\\n' ;;
+    esac
+elif [ "$1 $2 $3" = "-m pip show" ]; then
+    exit 1
+fi
+exit 0
+""",
+    )
+    _write_executable(
+        bin_dir / "tvly",
+        """#!/bin/sh
+if [ "$1" = "--version" ]; then
+    printf 'tavily-cli 0.1.8\\n'
+fi
+exit 0
+""",
+    )
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}:/usr/bin:/bin",
+        "TVLY_INSTALL_TEST_LOG": str(log_file),
+    }
+
+    result = subprocess.run(
+        ["/bin/sh", str(INSTALL_SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "python3 -m pip install --user --upgrade tavily-cli" in log_file.read_text().splitlines()
+    assert "/home/test-user/.local/bin is not in your PATH" in result.stdout
+    assert "site-packages/bin" not in result.stdout
+
+
+@pytest.mark.skipif(pty is None, reason="install.sh is a POSIX installer")
+def test_existing_pipx_install_wins_over_available_uv(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_file = tmp_path / "calls.log"
+    old_python = """#!/bin/sh
+if [ "$1" = "-c" ]; then
+    printf '3.9\\n'
+fi
+exit 0
+"""
+    _write_executable(bin_dir / "python3", old_python)
+    _write_executable(bin_dir / "python", old_python)
+    _write_executable(
+        bin_dir / "uv",
+        """#!/bin/sh
+printf 'uv %s\\n' "$*" >> "$TVLY_INSTALL_TEST_LOG"
+if [ "$1 $2" = "tool list" ]; then
+    exit 0
+fi
+if [ "$1 $2" = "tool install" ]; then
+    exit 1
 fi
 exit 0
 """,
@@ -308,8 +387,73 @@ exit 0
 
     assert status == 0
     assert log_file.read_text().splitlines() == [
+        "uv tool list",
         "pipx list --short",
         "pipx upgrade tavily-cli",
         "tvly --version",
     ]
     assert "Starting guided Tavily setup" not in output
+
+
+def test_existing_pip_install_wins_over_available_uv(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_file = tmp_path / "calls.log"
+    _write_executable(
+        bin_dir / "uv",
+        """#!/bin/sh
+printf 'uv %s\\n' "$*" >> "$TVLY_INSTALL_TEST_LOG"
+if [ "$1 $2" = "tool list" ]; then
+    exit 0
+fi
+if [ "$1 $2" = "tool install" ]; then
+    exit 1
+fi
+exit 0
+""",
+    )
+    _write_executable(
+        bin_dir / "python3",
+        """#!/bin/sh
+printf 'python3 %s\\n' "$*" >> "$TVLY_INSTALL_TEST_LOG"
+if [ "$1" = "--version" ]; then
+    printf 'Python 3.11.0\\n'
+elif [ "$1" = "-c" ]; then
+    case "$2" in
+        *version_info*) printf '3.11\\n' ;;
+        *sys.prefix*) printf '1\\n' ;;
+    esac
+elif [ "$1 $2 $3" = "-m pip show" ]; then
+    exit 0
+fi
+exit 0
+""",
+    )
+    _write_executable(
+        bin_dir / "tvly",
+        """#!/bin/sh
+printf 'tvly %s\\n' "$*" >> "$TVLY_INSTALL_TEST_LOG"
+if [ "$1" = "--version" ]; then
+    printf 'tavily-cli 0.1.8\\n'
+fi
+exit 0
+""",
+    )
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}:/usr/bin:/bin",
+        "TVLY_INSTALL_TEST_LOG": str(log_file),
+    }
+
+    result = subprocess.run(
+        ["/bin/sh", str(INSTALL_SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    calls = log_file.read_text().splitlines()
+    assert "uv tool install tavily-cli" not in calls
+    assert "python3 -m pip install --upgrade tavily-cli" in calls


### PR DESCRIPTION
## Summary

- send existing uv-managed installations directly through `uv tool upgrade`
- send existing pipx-managed installations directly through `pipx upgrade`
- reserve the managers' `install` commands for fresh installations
- preserve the fresh-install-only `tvly init` handoff
- update installer regression coverage for both upgrade and failed fresh-install paths

## Why

Both `uv tool install tavily-cli` and `pipx install tavily-cli` can return exit code 0 when the tool already exists. The previous failure-based fallbacks therefore never reached the managers' upgrade commands. Rerunning `install.sh` could report success while leaving an older CLI unchanged.

## Verification

- 108 tests passed on Python 3.10, 3.11, 3.12, and 3.13
- 10 dedicated installer tests passed
- Ruff passed
- POSIX shell syntax validation passed
- isolated real uv E2E upgraded an unpinned Tavily CLI 0.1.5 environment to 0.1.7
- isolated real pipx E2E upgraded Tavily CLI 0.1.6 to 0.1.7
