### PR TITLE
feat: add artifact-first CLI output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ env/
 .env
 .env.local
 
+# Generated Tavily artifacts
+.tavily/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -215,6 +215,18 @@ tvly auth --json
 tvly extract https://example.com --json
 tvly update --check --json
 
+# Durable artifacts: format follows the extension
+tvly search "query" -o results.json
+tvly extract https://example.com -o article.md
+
+# Generate authoritative JSON under .tavily/<command>/
+tvly search "query" --save
+
+# Keep agent stdout bounded and inspect only the fields you need
+summary=$(tvly search "query" --save --json)
+artifact=$(printf '%s' "$summary" | jq -r '.artifacts[0]')
+jq '.results[:5] | map({title, url, score})' "$artifact"
+
 # Read input from stdin with "-"
 echo "What is the latest funding for Anthropic?" | tvly search - --json
 echo "Research question" | tvly research - --json
@@ -229,6 +241,10 @@ tvly --version         # show version
 tvly --status          # show version + auth status
 tvly --status --json   # structured status
 ```
+
+`-o` writes Markdown for `.md`/`.markdown` paths and JSON otherwise. `--json`
+always forces JSON. Saved commands print only a short summary and the artifact
+path; existing files are preserved unless `--force` is provided.
 
 ### Exit Codes
 
@@ -259,7 +275,9 @@ tvly --status --json   # structured status
 | `--include-raw-content` | Include full page (`markdown` or `text`) |
 | `--include-images` | Include image results |
 | `--chunks-per-source` | Chunks per source (advanced/fast depth only) |
-| `-o` / `--output` | Save output to file |
+| `-o` / `--output` | Save JSON (`.json`) or Markdown (`.md`) |
+| `--save` | Save JSON to a generated path under `.tavily/search/` |
+| `--force` | Overwrite an existing `--output` file |
 | `--client-name` | Set optional `client_name` for request attribution |
 
 ### `tvly update`
@@ -287,7 +305,9 @@ automation can distinguish an available release from a supported self-update.
 | `--format` | `markdown` (default) or `text` |
 | `--include-images` | Include image URLs |
 | `--timeout` | Max wait (1-60 seconds) |
-| `-o` / `--output` | Save output to file |
+| `-o` / `--output` | Save JSON (`.json`) or complete Markdown (`.md`) |
+| `--save` | Save JSON to a generated path under `.tavily/extract/` |
+| `--force` | Overwrite an existing `--output` file |
 | `--client-name` | Set optional `client_name` for request attribution |
 
 ### `tvly crawl`
@@ -324,7 +344,9 @@ automation can distinguish an available release from a supported self-update.
 | `--exclude-paths` | Regex patterns for paths to exclude |
 | `--allow-external` | Include external links |
 | `--timeout` | Max wait (10-150 seconds) |
-| `-o` / `--output` | Save output to file |
+| `-o` / `--output` | Save JSON (`.json`) or Markdown (`.md`) |
+| `--save` | Save JSON to a generated path under `.tavily/map/` |
+| `--force` | Overwrite an existing `--output` file |
 | `--client-name` | Set optional `client_name` for request attribution |
 
 ### `tvly research <query>` / `tvly research run <query>`
@@ -338,7 +360,9 @@ automation can distinguish an available release from a supported self-update.
 | `--citation-format` | `numbered`, `mla`, `apa`, `chicago` |
 | `--poll-interval` | Seconds between checks (default: 10) |
 | `--timeout` | Max wait seconds (default: 600) |
-| `-o` / `--output` | Save output to file |
+| `-o` / `--output` | Save JSON (`.json`) or Markdown (`.md`) |
+| `--save` | Save `report.md` and `report.json` under `.tavily/research/` |
+| `--force` | Overwrite existing output files |
 | `--client-name` | Set optional `client_name` for request attribution |
 
 ### `tvly research status`
@@ -347,7 +371,7 @@ Check research task status by request ID. Supports `--client-name`.
 
 ### `tvly research poll`
 
-Poll until completion and return results. Same `--poll-interval`, `--timeout`, `-o`, and `--client-name` options as `run`.
+Poll until completion and return results. Same `--poll-interval`, `--timeout`, `-o`, `--save`, `--force`, and `--client-name` options as `run`.
 
 ## Environment Variables
 

--- a/tavily_cli/commands/extract.py
+++ b/tavily_cli/commands/extract.py
@@ -22,7 +22,9 @@ from tavily_cli.common import (
 @click.option("--format", "fmt", type=click.Choice(["markdown", "text"]), default=None, help="Output format.")
 @click.option("--include-images", is_flag=True, default=False, help="Include image URLs.")
 @click.option("--timeout", type=float, default=None, help="Max wait time in seconds (1-60).")
-@click.option("--output", "-o", "output_file", default=None, help="Save output to file.")
+@click.option("--output", "-o", "output_file", default=None, help="Save as JSON (.json) or Markdown (.md).")
+@click.option("--save", is_flag=True, default=False, help="Save JSON under .tavily/extract/.")
+@click.option("--force", is_flag=True, default=False, help="Overwrite an existing output file.")
 @client_name_option
 @json_option
 def extract(
@@ -34,6 +36,8 @@ def extract(
     include_images: bool,
     timeout: float | None,
     output_file: str | None,
+    save: bool,
+    force: bool,
     client_name: str | None,
     json_output: bool,
 ) -> None:
@@ -45,7 +49,13 @@ def extract(
     `tvly login` to authenticate and remove the cap.
     """
     from tavily_cli.config import get_client_or_keyless
-    from tavily_cli.output import print_extract_results
+    from tavily_cli.output import print_extract_results, validate_artifact_options
+
+    validate_artifact_options(
+        output_file=output_file,
+        save=save,
+        force=force,
+    )
 
     url_list = list(urls)
     if len(url_list) > 20:
@@ -79,4 +89,10 @@ def extract(
     except Exception as e:
         handle_api_error(e, json_output)
 
-    print_extract_results(response, json_mode=json_output, output_file=output_file)
+    print_extract_results(
+        response,
+        json_mode=json_output,
+        output_file=output_file,
+        save=save,
+        force=force,
+    )

--- a/tavily_cli/commands/map_cmd.py
+++ b/tavily_cli/commands/map_cmd.py
@@ -19,7 +19,9 @@ from tavily_cli.common import client_name_option, handle_api_error, json_option
 @click.option("--exclude-domains", default=None, help="Comma-separated regex patterns for domains to exclude.")
 @click.option("--allow-external/--no-external", default=None, help="Include external domain links.")
 @click.option("--timeout", type=float, default=None, help="Max wait time in seconds (10-150).")
-@click.option("--output", "-o", "output_file", default=None, help="Save output to file.")
+@click.option("--output", "-o", "output_file", default=None, help="Save as JSON (.json) or Markdown (.md).")
+@click.option("--save", is_flag=True, default=False, help="Save JSON under .tavily/map/.")
+@click.option("--force", is_flag=True, default=False, help="Overwrite an existing output file.")
 @client_name_option
 @json_option
 def map_urls(
@@ -35,6 +37,8 @@ def map_urls(
     allow_external: bool | None,
     timeout: float | None,
     output_file: str | None,
+    save: bool,
+    force: bool,
     client_name: str | None,
     json_output: bool,
 ) -> None:
@@ -45,7 +49,13 @@ def map_urls(
     Requires a Tavily API key. Sign up at https://tavily.com
     """
     from tavily_cli.config import get_client, require_api_key_friendly
-    from tavily_cli.output import print_map_results
+    from tavily_cli.output import print_map_results, validate_artifact_options
+
+    validate_artifact_options(
+        output_file=output_file,
+        save=save,
+        force=force,
+    )
 
     require_api_key_friendly("map", json_mode=json_output)
     client = get_client(client_name=client_name, json_mode=json_output)
@@ -80,4 +90,10 @@ def map_urls(
     except Exception as e:
         handle_api_error(e, json_output)
 
-    print_map_results(response, json_mode=json_output, output_file=output_file)
+    print_map_results(
+        response,
+        json_mode=json_output,
+        output_file=output_file,
+        save=save,
+        force=force,
+    )

--- a/tavily_cli/commands/research.py
+++ b/tavily_cli/commands/research.py
@@ -58,7 +58,14 @@ def _resolve_json(ctx: click.Context, local_flag: bool) -> bool:
     return False
 
 
-def _render_stream(stream_resp, *, output_file: str | None = None) -> None:
+def _render_stream(
+    stream_resp,
+    *,
+    json_mode: bool = False,
+    output_file: str | None = None,
+    save: bool = False,
+    force: bool = False,
+) -> None:
     """Parse SSE stream chunks, show live status, then render with Rich like non-stream."""
     from tavily_cli.output import print_research_result
     from tavily_cli.theme import err_console
@@ -116,7 +123,13 @@ def _render_stream(stream_resp, *, output_file: str | None = None) -> None:
         "content": full_content,
         "sources": sources,
     }
-    print_research_result(result, json_mode=False, output_file=output_file)
+    print_research_result(
+        result,
+        json_mode=json_mode,
+        output_file=output_file,
+        save=save,
+        force=force,
+    )
 
 
 @research.command()
@@ -126,7 +139,9 @@ def _render_stream(stream_resp, *, output_file: str | None = None) -> None:
 @click.option("--stream", is_flag=True, default=False, help="Stream results in real-time.")
 @click.option("--output-schema", default=None, help="Path to JSON schema file for structured output.")
 @click.option("--citation-format", type=click.Choice(["numbered", "mla", "apa", "chicago"]), default=None, help="Citation format.")
-@click.option("--output", "-o", "output_file", default=None, help="Save output to file.")
+@click.option("--output", "-o", "output_file", default=None, help="Save as JSON (.json) or Markdown (.md).")
+@click.option("--save", is_flag=True, default=False, help="Save report.md and report.json under .tavily/research/.")
+@click.option("--force", is_flag=True, default=False, help="Overwrite existing output files.")
 @click.option("--poll-interval", type=int, default=10, help="Seconds between status checks (default: 10).")
 @click.option("--timeout", type=int, default=600, help="Max seconds to wait (default: 600).")
 @click.option("--json", "json_flag", is_flag=True, default=False, help="Output as JSON.")
@@ -141,6 +156,8 @@ def run(
     output_schema: str | None,
     citation_format: str | None,
     output_file: str | None,
+    save: bool,
+    force: bool,
     poll_interval: int,
     timeout: int,
     json_flag: bool,
@@ -155,7 +172,7 @@ def run(
     Requires a Tavily API key. Sign up at https://tavily.com
     """
     from tavily_cli.config import get_client, require_api_key_friendly
-    from tavily_cli.output import emit, print_research_result
+    from tavily_cli.output import emit, print_research_result, validate_artifact_options
 
     json_mode = _resolve_json(ctx, json_flag)
 
@@ -163,6 +180,12 @@ def run(
         query = sys.stdin.read(100_000).strip()
     if not query:
         raise click.UsageError("QUERY is required. Pass a query string or use '-' to read from stdin.")
+
+    validate_artifact_options(
+        output_file=output_file,
+        save=save,
+        force=force,
+    )
 
     require_api_key_friendly("research", json_mode=json_mode)
     client = get_client(client_name=client_name, json_mode=json_mode)
@@ -186,7 +209,7 @@ def run(
         kwargs["stream"] = True
         try:
             stream_resp = client.research(**kwargs)
-            if json_mode:
+            if json_mode and not (output_file or save):
                 # Re-serialize each SSE event as one JSON line (NDJSON) rather
                 # than forwarding raw SSE bytes: this keeps the output valid,
                 # machine-parseable JSON and lets json.dumps escape any control
@@ -206,7 +229,15 @@ def run(
                             continue
                         click.echo(json.dumps(event, ensure_ascii=False))
             else:
-                _render_stream(stream_resp, output_file=output_file)
+                _render_stream(
+                    stream_resp,
+                    json_mode=json_mode,
+                    output_file=output_file,
+                    save=save,
+                    force=force,
+                )
+        except click.ClickException:
+            raise
         except Exception as e:
             handle_api_error(e, json_mode)
         return
@@ -220,7 +251,13 @@ def run(
     # If the initial response is already complete (e.g., MCP endpoint returns
     # the full result synchronously), skip polling entirely.
     if result.get("status") in ("completed", "failed") or result.get("content"):
-        print_research_result(result, json_mode=json_mode, output_file=output_file)
+        print_research_result(
+            result,
+            json_mode=json_mode,
+            output_file=output_file,
+            save=save,
+            force=force,
+        )
         return
 
     request_id = result.get("request_id")
@@ -229,7 +266,17 @@ def run(
         handle_api_error(RuntimeError(f"Unexpected API response: {result}"), json_mode)
 
     if no_wait:
-        emit({"request_id": request_id, "status": result.get("status", "pending")}, json_mode=True, output_file=output_file)
+        pending_result = {"request_id": request_id, "status": result.get("status", "pending")}
+        if output_file or save:
+            print_research_result(
+                pending_result,
+                json_mode=json_mode,
+                output_file=output_file,
+                save=save,
+                force=force,
+            )
+        else:
+            emit(pending_result, json_mode=True)
         return
 
     elapsed = 0
@@ -246,7 +293,17 @@ def run(
             time.sleep(poll_interval)
             elapsed += poll_interval
         else:
-            emit({"request_id": request_id, "status": "timeout"}, json_mode=True, output_file=output_file)
+            timeout_result = {"request_id": request_id, "status": "timeout"}
+            if output_file or save:
+                print_research_result(
+                    timeout_result,
+                    json_mode=json_mode,
+                    output_file=output_file,
+                    save=save,
+                    force=force,
+                )
+            else:
+                emit(timeout_result, json_mode=True)
             return
     else:
         # Rich mode: live spinner with running elapsed time
@@ -266,9 +323,23 @@ def run(
                 elapsed += 1
             else:
                 err_console.print(f"[#FFC769]Timed out after {timeout}s. Resume with: tvly research poll {escape(sanitize_control(request_id))}[/#FFC769]")
+                if output_file or save:
+                    print_research_result(
+                        {"request_id": request_id, "status": "timeout"},
+                        json_mode=json_mode,
+                        output_file=output_file,
+                        save=save,
+                        force=force,
+                    )
                 return
 
-    print_research_result(response, json_mode=json_mode, output_file=output_file)
+    print_research_result(
+        response,
+        json_mode=json_mode,
+        output_file=output_file,
+        save=save,
+        force=force,
+    )
 
 
 @research.command()
@@ -309,7 +380,9 @@ def status(ctx: click.Context, request_id: str, json_flag: bool, client_name: st
 @click.argument("request_id")
 @click.option("--poll-interval", type=int, default=10, help="Seconds between status checks (default: 10).")
 @click.option("--timeout", type=int, default=600, help="Max seconds to wait (default: 600).")
-@click.option("--output", "-o", "output_file", default=None, help="Save output to file.")
+@click.option("--output", "-o", "output_file", default=None, help="Save as JSON (.json) or Markdown (.md).")
+@click.option("--save", is_flag=True, default=False, help="Save report.md and report.json under .tavily/research/.")
+@click.option("--force", is_flag=True, default=False, help="Overwrite existing output files.")
 @click.option("--json", "json_flag", is_flag=True, default=False, help="Output as JSON.")
 @client_name_option
 @click.pass_context
@@ -319,15 +392,22 @@ def poll(
     poll_interval: int,
     timeout: int,
     output_file: str | None,
+    save: bool,
+    force: bool,
     json_flag: bool,
     client_name: str | None,
 ) -> None:
     """Poll a research task until completion and return results."""
     from tavily_cli.config import get_client, require_api_key_friendly
-    from tavily_cli.output import emit, print_research_result
+    from tavily_cli.output import emit, print_research_result, validate_artifact_options
     from tavily_cli.theme import err_console
 
     json_mode = _resolve_json(ctx, json_flag)
+    validate_artifact_options(
+        output_file=output_file,
+        save=save,
+        force=force,
+    )
     require_api_key_friendly("research poll", json_mode=json_mode)
     client = get_client(client_name=client_name, json_mode=json_mode)
 
@@ -344,7 +424,17 @@ def poll(
             time.sleep(poll_interval)
             elapsed += poll_interval
         else:
-            emit({"request_id": request_id, "status": "timeout"}, json_mode=True, output_file=output_file)
+            timeout_result = {"request_id": request_id, "status": "timeout"}
+            if output_file or save:
+                print_research_result(
+                    timeout_result,
+                    json_mode=json_mode,
+                    output_file=output_file,
+                    save=save,
+                    force=force,
+                )
+            else:
+                emit(timeout_result, json_mode=True)
             return
     else:
         with err_console.status("", spinner="dots") as live:
@@ -363,6 +453,20 @@ def poll(
                 elapsed += 1
             else:
                 err_console.print(f"[#FFC769]Timed out after {timeout}s.[/#FFC769]")
+                if output_file or save:
+                    print_research_result(
+                        {"request_id": request_id, "status": "timeout"},
+                        json_mode=json_mode,
+                        output_file=output_file,
+                        save=save,
+                        force=force,
+                    )
                 return
 
-    print_research_result(response, json_mode=json_mode, output_file=output_file)
+    print_research_result(
+        response,
+        json_mode=json_mode,
+        output_file=output_file,
+        save=save,
+        force=force,
+    )

--- a/tavily_cli/commands/search.py
+++ b/tavily_cli/commands/search.py
@@ -32,7 +32,9 @@ from tavily_cli.common import (
 @click.option("--include-images", is_flag=True, default=False, help="Include image results.")
 @click.option("--include-image-descriptions", is_flag=True, default=False, help="Include AI image descriptions.")
 @click.option("--chunks-per-source", type=int, default=None, help="Chunks per source (advanced/fast depth only).")
-@click.option("--output", "-o", "output_file", default=None, help="Save output to file.")
+@click.option("--output", "-o", "output_file", default=None, help="Save as JSON (.json) or Markdown (.md).")
+@click.option("--save", is_flag=True, default=False, help="Save JSON under .tavily/search/.")
+@click.option("--force", is_flag=True, default=False, help="Overwrite an existing output file.")
 @client_name_option
 @json_option
 def search(
@@ -52,6 +54,8 @@ def search(
     include_image_descriptions: bool,
     chunks_per_source: int | None,
     output_file: str | None,
+    save: bool,
+    force: bool,
     client_name: str | None,
     json_output: bool,
 ) -> None:
@@ -63,12 +67,18 @@ def search(
     `tvly login` to authenticate and remove the cap.
     """
     from tavily_cli.config import get_client_or_keyless
-    from tavily_cli.output import print_search_results
+    from tavily_cli.output import print_search_results, validate_artifact_options
 
     if query == "-":
         query = sys.stdin.read(100_000).strip()
     if not query:
         raise click.UsageError("QUERY is required. Pass a query string or use '-' to read from stdin.")
+
+    validate_artifact_options(
+        output_file=output_file,
+        save=save,
+        force=force,
+    )
 
     kwargs: dict = {"query": query}
     if search_depth is not None:
@@ -114,4 +124,10 @@ def search(
     except Exception as e:
         handle_api_error(e, json_output)
 
-    print_search_results(response, json_mode=json_output, output_file=output_file)
+    print_search_results(
+        response,
+        json_mode=json_output,
+        output_file=output_file,
+        save=save,
+        force=force,
+    )

--- a/tavily_cli/output.py
+++ b/tavily_cli/output.py
@@ -1,4 +1,4 @@
-"""Output formatting: Rich for humans, JSON for agents, -o for file output.
+"""Output formatting: Rich for humans and durable artifacts for agents.
 
 All human-readable rendering treats result fields (titles, URLs, snippets,
 answers, page content, source lists, error text) as untrusted: they originate
@@ -11,6 +11,11 @@ and rendered via ``Text``/validated links rather than markup-bearing f-strings.
 from __future__ import annotations
 
 import json
+import os
+import tempfile
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
@@ -90,38 +95,294 @@ def _domain(url: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# JSON / file emit
+# JSON / artifact emit
 # ---------------------------------------------------------------------------
 
-def emit(data: Any, *, json_mode: bool, output_file: str | None = None, pretty: bool = False) -> None:
+_MARKDOWN_SUFFIXES = {".md", ".markdown"}
+
+
+def validate_artifact_options(
+    *,
+    output_file: str | None,
+    save: bool,
+    force: bool,
+) -> None:
+    """Validate shared artifact flags before making an API request."""
+    if output_file and save:
+        raise click.UsageError("Use either --output or --save, not both.")
+    if force and not (output_file or save):
+        raise click.UsageError("--force requires --output or --save.")
+    if output_file:
+        path = Path(output_file)
+        if not path.parent.exists():
+            raise click.ClickException(f"Output directory does not exist: {path.parent}")
+        if path.exists() and not force:
+            raise click.ClickException(f"Refusing to overwrite existing file: {path}. Use --force to overwrite.")
+
+
+def _json_text(data: Any, *, pretty: bool) -> str:
+    return json.dumps(data, indent=2 if pretty else None, ensure_ascii=False) + "\n"
+
+
+def _atomic_write_text(path: Path, text: str, *, force: bool, create_parents: bool = False) -> None:
+    """Atomically publish a complete text file, refusing collisions by default."""
+    parent = path.parent
+    if create_parents:
+        parent.mkdir(parents=True, exist_ok=True)
+    elif not parent.exists():
+        raise click.ClickException(f"Output directory does not exist: {parent}")
+
+    if path.exists() and not force:
+        raise click.ClickException(f"Refusing to overwrite existing file: {path}. Use --force to overwrite.")
+
+    temp_path: Path | None = None
+    try:
+        fd, raw_temp_path = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=parent)
+        temp_path = Path(raw_temp_path)
+        with os.fdopen(fd, "w", encoding="utf-8") as temp_file:
+            temp_file.write(text)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+
+        if force:
+            os.replace(temp_path, path)
+        else:
+            # A hard-link publish is atomic and fails if another process creates
+            # the destination between the preflight check and this operation.
+            os.link(temp_path, path)
+            temp_path.unlink()
+        temp_path = None
+    except FileExistsError as exc:
+        raise click.ClickException(
+            f"Refusing to overwrite existing file: {path}. Use --force to overwrite."
+        ) from exc
+    except OSError as exc:
+        raise click.ClickException(f"Could not write artifact {path}: {exc}") from exc
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink()
+            except FileNotFoundError:
+                pass
+
+
+def _artifact_timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+
+
+def _print_artifact_summary(summary: str, paths: list[Path], *, json_mode: bool) -> None:
+    rendered_paths = [str(path) for path in paths]
+    if json_mode:
+        click.echo(json.dumps({"saved": True, "summary": summary, "artifacts": rendered_paths}))
+        return
+
+    click.echo(summary)
+    for path in rendered_paths:
+        click.echo(f"Artifact: {path}")
+
+
+def _save_result(
+    data: dict,
+    *,
+    command: str,
+    json_mode: bool,
+    output_file: str | None,
+    save: bool,
+    force: bool,
+    markdown_renderer: Callable[[dict], str],
+    summary: str,
+) -> bool:
+    """Save one command result and print a bounded artifact summary."""
+    if not output_file and not save:
+        return False
+
+    if save and command == "research":
+        output_dir = Path(".tavily") / command / _artifact_timestamp()
+        markdown_path = output_dir / "report.md"
+        json_path = output_dir / "report.json"
+        _atomic_write_text(markdown_path, markdown_renderer(data), force=force, create_parents=True)
+        _atomic_write_text(json_path, _json_text(data, pretty=True), force=force, create_parents=True)
+        _print_artifact_summary(summary, [markdown_path, json_path], json_mode=json_mode)
+        return True
+
+    path = Path(output_file) if output_file else Path(".tavily") / command / f"{_artifact_timestamp()}.json"
+    use_markdown = not json_mode and path.suffix.lower() in _MARKDOWN_SUFFIXES
+    text = markdown_renderer(data) if use_markdown else _json_text(data, pretty=True)
+    _atomic_write_text(path, text, force=force, create_parents=save)
+    _print_artifact_summary(summary, [path], json_mode=json_mode)
+    return True
+
+
+def emit(
+    data: Any,
+    *,
+    json_mode: bool,
+    output_file: str | None = None,
+    pretty: bool = False,
+    force: bool = True,
+) -> None:
     """Write JSON data to stdout (or a file). Used in --json mode.
 
     json.dumps escapes control characters (incl. ESC) as \\uXXXX, so this path
     is safe from terminal-escape injection without extra stripping.
     """
-    text = json.dumps(data, indent=2 if pretty else None, ensure_ascii=False)
+    text = _json_text(data, pretty=pretty)
     if output_file:
-        with open(output_file, "w", encoding="utf-8") as f:
-            f.write(text + "\n")
+        _atomic_write_text(Path(output_file), text, force=force)
         err_console.print(f"Output saved to {output_file}")
     else:
-        click.echo(text)
+        click.echo(text, nl=False)
+
+
+def _one_line(value: Any) -> str:
+    return " ".join(sanitize_control(value).splitlines()).strip()
+
+
+def _structured_markdown(value: Any) -> str:
+    if isinstance(value, (dict, list)):
+        return f"```json\n{json.dumps(value, indent=2, ensure_ascii=False)}\n```"
+    return sanitize_control(value)
+
+
+def _search_markdown(data: dict) -> str:
+    lines = ["# Search Results"]
+    answer = data.get("answer")
+    if answer:
+        lines.extend(["", "## Answer", "", _structured_markdown(answer)])
+
+    results = data.get("results") or []
+    if results:
+        lines.extend(["", "## Results"])
+        for index, result in enumerate(results, 1):
+            title = _one_line(result.get("title", "Untitled")) or "Untitled"
+            lines.extend(["", f"### {index}. {title}", ""])
+            if result.get("url"):
+                lines.append(f"Source: {sanitize_control(result['url'])}")
+            if result.get("score") is not None:
+                lines.append(f"Score: {sanitize_control(result['score'])}")
+            if result.get("content"):
+                lines.extend(["", _structured_markdown(result["content"])])
+            if result.get("raw_content"):
+                lines.extend(["", "#### Full content", "", _structured_markdown(result["raw_content"])])
+    elif not answer:
+        lines.extend(["", "No results found."])
+
+    images = data.get("images") or []
+    if images:
+        lines.extend(["", "## Images", ""])
+        for image in images:
+            if isinstance(image, dict):
+                url = sanitize_control(image.get("url", ""))
+                description = _one_line(image.get("description", ""))
+                lines.append(f"- {url}" + (f" - {description}" if description else ""))
+            else:
+                lines.append(f"- {sanitize_control(image)}")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _extract_markdown(data: dict) -> str:
+    lines = ["# Extracted Content"]
+    results = data.get("results") or []
+    if not results:
+        lines.extend(["", "No content extracted."])
+
+    for index, result in enumerate(results, 1):
+        url = sanitize_control(result.get("url", ""))
+        lines.extend(["", f"## {index}. {_one_line(url) or 'Untitled'}", ""])
+        if url:
+            lines.extend([f"Source: {url}", ""])
+        raw_content = result.get("raw_content")
+        lines.append(_structured_markdown(raw_content) if raw_content else "No content.")
+
+        images = result.get("images") or []
+        if images:
+            lines.extend(["", "### Images", ""])
+            lines.extend(f"- {sanitize_control(image)}" for image in images)
+
+    failed = data.get("failed_results") or []
+    if failed:
+        lines.extend(["", "## Failed Extractions", ""])
+        for item in failed:
+            lines.append(
+                f"- {sanitize_control(item.get('url', ''))}: {sanitize_control(item.get('error', 'Unknown error'))}"
+            )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _map_markdown(data: dict) -> str:
+    lines = ["# URL Map"]
+    if data.get("base_url"):
+        lines.extend(["", f"Base URL: {sanitize_control(data['base_url'])}"])
+    results = data.get("results") or []
+    if results:
+        lines.append("")
+        for result in results:
+            url = result.get("url", "") if isinstance(result, dict) else result
+            lines.append(f"- {sanitize_control(url)}")
+    else:
+        lines.extend(["", "No URLs found."])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _research_markdown(data: dict) -> str:
+    lines = ["# Research Report"]
+    status = data.get("status", "unknown")
+    lines.extend(["", f"Status: {sanitize_control(status)}"])
+    if data.get("request_id"):
+        lines.append(f"Request ID: {sanitize_control(data['request_id'])}")
+    if data.get("error"):
+        lines.extend(["", f"Error: {sanitize_control(data['error'])}"])
+
+    content = data.get("content")
+    if content:
+        lines.extend(["", _structured_markdown(content)])
+
+    sources = data.get("sources") or []
+    if sources:
+        lines.extend(["", "## Sources", ""])
+        for index, source in enumerate(sources, 1):
+            if isinstance(source, dict):
+                title = _one_line(source.get("title", ""))
+                url = sanitize_control(source.get("url", ""))
+                label = title or url or f"Source {index}"
+                lines.append(f"{index}. {label}" + (f" - {url}" if url and url != label else ""))
+            else:
+                lines.append(f"{index}. {sanitize_control(source)}")
+
+    return "\n".join(lines).rstrip() + "\n"
 
 
 # ---------------------------------------------------------------------------
 # Search
 # ---------------------------------------------------------------------------
 
-def print_search_results(data: dict, *, json_mode: bool, output_file: str | None = None) -> None:
+def print_search_results(
+    data: dict,
+    *,
+    json_mode: bool,
+    output_file: str | None = None,
+    save: bool = False,
+    force: bool = False,
+) -> None:
+    results = data.get("results") or []
+    if _save_result(
+        data,
+        command="search",
+        json_mode=json_mode,
+        output_file=output_file,
+        save=save,
+        force=force,
+        markdown_renderer=_search_markdown,
+        summary=f"Saved {len(results)} search result{'s' if len(results) != 1 else ''}.",
+    ):
+        return
+
     if json_mode:
-        emit(data, json_mode=True, output_file=output_file, pretty=True)
+        emit(data, json_mode=True, pretty=True)
         return
 
-    if output_file:
-        emit(data, json_mode=True, output_file=output_file, pretty=True)
-        return
-
-    results = data.get("results", [])
     answer = data.get("answer")
     response_time = data.get("response_time")
 
@@ -179,13 +440,31 @@ def print_search_results(data: dict, *, json_mode: bool, output_file: str | None
 # Extract
 # ---------------------------------------------------------------------------
 
-def print_extract_results(data: dict, *, json_mode: bool, output_file: str | None = None) -> None:
-    if json_mode or output_file:
-        emit(data, json_mode=True, output_file=output_file, pretty=True)
+def print_extract_results(
+    data: dict,
+    *,
+    json_mode: bool,
+    output_file: str | None = None,
+    save: bool = False,
+    force: bool = False,
+) -> None:
+    results = data.get("results") or []
+    failed = data.get("failed_results") or []
+    if _save_result(
+        data,
+        command="extract",
+        json_mode=json_mode,
+        output_file=output_file,
+        save=save,
+        force=force,
+        markdown_renderer=_extract_markdown,
+        summary=f"Saved {len(results)} extraction{'s' if len(results) != 1 else ''} ({len(failed)} failed).",
+    ):
         return
 
-    results = data.get("results", [])
-    failed = data.get("failed_results", [])
+    if json_mode:
+        emit(data, json_mode=True, pretty=True)
+        return
 
     for r in results:
         url = r.get("url", "")
@@ -202,6 +481,9 @@ def print_extract_results(data: dict, *, json_mode: bool, output_file: str | Non
         console.print()
         if raw:
             console.print(Markdown(sanitize_control(raw[:3000])), width=min(console.width, 100))
+            if len(raw) > 3000:
+                console.print()
+                console.print("  [dim]Content truncated. Use --save or -o article.md for the complete extraction.[/dim]")
         else:
             console.print("  [dim]No content[/dim]")
         console.print()
@@ -301,12 +583,31 @@ def _save_crawl_to_dir(data: dict, output_dir: str) -> None:
 # Map
 # ---------------------------------------------------------------------------
 
-def print_map_results(data: dict, *, json_mode: bool, output_file: str | None = None) -> None:
-    if json_mode or output_file:
-        emit(data, json_mode=True, output_file=output_file, pretty=True)
+def print_map_results(
+    data: dict,
+    *,
+    json_mode: bool,
+    output_file: str | None = None,
+    save: bool = False,
+    force: bool = False,
+) -> None:
+    results = data.get("results") or []
+    if _save_result(
+        data,
+        command="map",
+        json_mode=json_mode,
+        output_file=output_file,
+        save=save,
+        force=force,
+        markdown_renderer=_map_markdown,
+        summary=f"Saved {len(results)} URL{'s' if len(results) != 1 else ''}.",
+    ):
         return
 
-    results = data.get("results", [])
+    if json_mode:
+        emit(data, json_mode=True, pretty=True)
+        return
+
     base_url = data.get("base_url", "")
 
     tree = Tree(_safe_text(base_url, style="bold"))
@@ -323,14 +624,33 @@ def print_map_results(data: dict, *, json_mode: bool, output_file: str | None = 
 # Research
 # ---------------------------------------------------------------------------
 
-def print_research_result(data: dict, *, json_mode: bool, output_file: str | None = None) -> None:
-    if json_mode or output_file:
-        emit(data, json_mode=True, output_file=output_file, pretty=True)
+def print_research_result(
+    data: dict,
+    *,
+    json_mode: bool,
+    output_file: str | None = None,
+    save: bool = False,
+    force: bool = False,
+) -> None:
+    sources = data.get("sources") or []
+    if _save_result(
+        data,
+        command="research",
+        json_mode=json_mode,
+        output_file=output_file,
+        save=save,
+        force=force,
+        markdown_renderer=_research_markdown,
+        summary=f"Saved research report with {len(sources)} source{'s' if len(sources) != 1 else ''}.",
+    ):
+        return
+
+    if json_mode:
+        emit(data, json_mode=True, pretty=True)
         return
 
     status = data.get("status", "unknown")
     content = data.get("content", "")
-    sources = data.get("sources", [])
 
     if status != "completed":
         status_line = Text()

--- a/tests/test_artifact_output.py
+++ b/tests/test_artifact_output.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from tavily_cli.commands.research import _render_stream
+from tavily_cli.commands.search import search
+from tavily_cli.output import (
+    print_extract_results,
+    print_map_results,
+    print_research_result,
+    print_search_results,
+    validate_artifact_options,
+)
+
+SEARCH_RESPONSE = {
+    "answer": "A concise answer.",
+    "results": [
+        {
+            "title": "Example result",
+            "url": "https://example.com/article",
+            "score": 0.9,
+            "content": "Result snippet.",
+            "raw_content": "Complete search content.",
+        }
+    ],
+}
+
+
+def test_output_extension_selects_json_or_markdown(tmp_path: Path) -> None:
+    json_path = tmp_path / "result.json"
+    markdown_path = tmp_path / "result.md"
+    legacy_path = tmp_path / "result.txt"
+
+    print_search_results(SEARCH_RESPONSE, json_mode=False, output_file=str(json_path))
+    print_search_results(SEARCH_RESPONSE, json_mode=False, output_file=str(markdown_path))
+    print_search_results(SEARCH_RESPONSE, json_mode=False, output_file=str(legacy_path))
+
+    assert json.loads(json_path.read_text()) == SEARCH_RESPONSE
+    assert json.loads(legacy_path.read_text()) == SEARCH_RESPONSE
+    markdown = markdown_path.read_text()
+    assert markdown.startswith("# Search Results")
+    assert "Example result" in markdown
+    assert "Complete search content." in markdown
+
+
+def test_extract_markdown_contains_complete_content(tmp_path: Path) -> None:
+    raw_content = "x" * 3_500 + " END"
+    output_path = tmp_path / "article.md"
+
+    print_extract_results(
+        {"results": [{"url": "https://example.com", "raw_content": raw_content}]},
+        json_mode=False,
+        output_file=str(output_path),
+    )
+
+    assert output_path.read_text().endswith(" END\n")
+
+
+def test_json_flag_forces_json_regardless_of_extension(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    output_path = tmp_path / "map.md"
+    response = {"base_url": "https://example.com", "results": ["https://example.com/a"]}
+
+    print_map_results(response, json_mode=True, output_file=str(output_path))
+
+    assert json.loads(output_path.read_text()) == response
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["saved"] is True
+    assert summary["artifacts"] == [str(output_path)]
+
+
+def test_existing_output_is_refused_unless_forced(tmp_path: Path) -> None:
+    output_path = tmp_path / "result.json"
+    output_path.write_text("original")
+
+    with pytest.raises(click.ClickException, match="Refusing to overwrite"):
+        print_search_results(SEARCH_RESPONSE, json_mode=False, output_file=str(output_path))
+
+    assert output_path.read_text() == "original"
+    print_search_results(SEARCH_RESPONSE, json_mode=False, output_file=str(output_path), force=True)
+    assert json.loads(output_path.read_text()) == SEARCH_RESPONSE
+    assert not list(tmp_path.glob(".*.tmp"))
+
+
+def test_save_generates_authoritative_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    response = {"results": [{"url": "https://example.com", "raw_content": "full content"}]}
+
+    print_extract_results(response, json_mode=False, save=True)
+
+    artifacts = list((tmp_path / ".tavily" / "extract").glob("*.json"))
+    assert len(artifacts) == 1
+    assert json.loads(artifacts[0].read_text()) == response
+
+
+def test_research_save_writes_report_and_metadata(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    response = {
+        "status": "completed",
+        "content": "# Findings\n\nComplete report.",
+        "sources": [{"title": "Source", "url": "https://example.com"}],
+        "response_time": 4.2,
+    }
+
+    print_research_result(response, json_mode=False, save=True)
+
+    artifact_dirs = list((tmp_path / ".tavily" / "research").iterdir())
+    assert len(artifact_dirs) == 1
+    assert "Complete report." in (artifact_dirs[0] / "report.md").read_text()
+    assert json.loads((artifact_dirs[0] / "report.json").read_text()) == response
+
+
+def test_streamed_research_can_be_saved_as_complete_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    chunks = [
+        "data:"
+        + json.dumps({"choices": [{"delta": {"content": "Complete "}}]}),
+        "data:"
+        + json.dumps(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "content": "report.",
+                            "sources": [{"title": "Source", "url": "https://example.com"}],
+                        }
+                    }
+                ]
+            }
+        ),
+    ]
+
+    _render_stream(chunks, save=True)
+
+    artifact_dir = next((tmp_path / ".tavily" / "research").iterdir())
+    assert "Complete report." in (artifact_dir / "report.md").read_text()
+    metadata = json.loads((artifact_dir / "report.json").read_text())
+    assert metadata["content"] == "Complete report."
+    assert metadata["sources"][0]["url"] == "https://example.com"
+
+
+def test_validation_rejects_conflicting_flags_and_existing_files(tmp_path: Path) -> None:
+    with pytest.raises(click.UsageError, match="either --output or --save"):
+        validate_artifact_options(output_file="result.json", save=True, force=False)
+
+    output_path = tmp_path / "result.json"
+    output_path.write_text("original")
+    with pytest.raises(click.ClickException, match="Refusing to overwrite"):
+        validate_artifact_options(
+            output_file=str(output_path),
+            save=False,
+            force=False,
+        )
+
+
+def test_search_command_wires_artifact_flags(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeClient:
+        def search(self, **kwargs):
+            assert kwargs["query"] == "artifact test"
+            return SEARCH_RESPONSE
+
+    monkeypatch.setattr(
+        "tavily_cli.config.get_client_or_keyless",
+        lambda **kwargs: (FakeClient(), True),
+    )
+    output_path = tmp_path / "search.md"
+
+    result = CliRunner().invoke(search, ["artifact test", "-o", str(output_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "Artifact:" in result.output
+    assert "Complete search content." in output_path.read_text()


### PR DESCRIPTION
## Summary

- make `--output` select JSON for `.json` paths and complete Markdown for `.md`/`.markdown` paths
- add generated `--save` artifacts under `.tavily/<command>/`
- save research as both `report.md` and `report.json`
- use atomic writes and refuse existing destinations unless `--force` is supplied
- keep stdout bounded when saving by returning a short summary and artifact paths
- update the bundled Tavily skills to treat saved files as authoritative and inspect only bounded sections

## Why

Large search, extraction, map, and research responses are frequently truncated when printed into an agent context. This makes the saved artifact the complete source of truth while preserving concise terminal output for humans and agents.

## Compatibility

- existing human output remains unchanged when no artifact option is used
- `--json` continues to force JSON regardless of filename extension
- paths without a Markdown extension retain the previous JSON behavior

## Test plan

- `python -m pytest -q` — 119 passed after rebasing onto current `origin/main`
- `ruff check tavily_cli tests`
- `uv build`

## Stack

This is the first PR. `feat/stable-machine-contract` is intentionally based on this branch because it extends these artifact writers with JSONL and partial-failure behavior.
