### PR TITLE
feat: stabilize machine-readable CLI behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,11 @@ tvly auth --json
 tvly extract https://example.com --json
 tvly update --check --json
 
+# Explicit JSON Lines for result sets and research streams
+tvly search "query" --jsonl
+tvly extract https://example.com https://example.org --jsonl
+tvly research "question" --stream --jsonl
+
 # Durable artifacts: format follows the extension
 tvly search "query" -o results.json
 tvly extract https://example.com -o article.md
@@ -246,6 +251,25 @@ tvly --status --json   # structured status
 always forces JSON. Saved commands print only a short summary and the artifact
 path; existing files are preserved unless `--force` is provided.
 
+Machine-readable failures use one stable envelope on stdout; progress and
+diagnostics remain on stderr:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "research_timeout",
+    "message": "Research timed out after 600s.",
+    "stage": "poll",
+    "retryable": true,
+    "request_id": "request-id"
+  }
+}
+```
+
+`--json` emits one JSON document. `--jsonl` emits typed result records followed
+by a summary record; with research streaming, each API event is one line.
+
 ### Exit Codes
 
 | Code | Meaning |
@@ -253,8 +277,9 @@ path; existing files are preserved unless `--force` is provided.
 | 0 | Success |
 | 1 | Local setup or update error |
 | 2 | Invalid input / usage error |
-| 3 | Authentication error |
+| 3 | Authentication or usage-limit error |
 | 4 | API or update-check error |
+| 5 | Partial result treated as failure by `--fail-on-partial` |
 
 ## Command Reference
 
@@ -278,6 +303,7 @@ path; existing files are preserved unless `--force` is provided.
 | `-o` / `--output` | Save JSON (`.json`) or Markdown (`.md`) |
 | `--save` | Save JSON to a generated path under `.tavily/search/` |
 | `--force` | Overwrite an existing `--output` file |
+| `--jsonl` | Emit one result per JSON line, followed by a summary |
 | `--client-name` | Set optional `client_name` for request attribution |
 
 ### `tvly update`
@@ -308,6 +334,8 @@ automation can distinguish an available release from a supported self-update.
 | `-o` / `--output` | Save JSON (`.json`) or complete Markdown (`.md`) |
 | `--save` | Save JSON to a generated path under `.tavily/extract/` |
 | `--force` | Overwrite an existing `--output` file |
+| `--fail-on-partial` | Exit 5 if any requested URL fails |
+| `--jsonl` | Emit one extraction per JSON line, followed by a summary |
 | `--client-name` | Set optional `client_name` for request attribution |
 
 ### `tvly crawl`
@@ -330,6 +358,7 @@ automation can distinguish an available release from a supported self-update.
 | `--timeout` | Max wait (10-150 seconds) |
 | `-o` / `--output` | Save JSON to file |
 | `--output-dir` | Save each page as .md file in directory |
+| `--jsonl` | Emit one crawled page per JSON line, followed by a summary |
 | `--client-name` | Set optional `client_name` for request attribution |
 
 ### `tvly map`
@@ -347,6 +376,7 @@ automation can distinguish an available release from a supported self-update.
 | `-o` / `--output` | Save JSON (`.json`) or Markdown (`.md`) |
 | `--save` | Save JSON to a generated path under `.tavily/map/` |
 | `--force` | Overwrite an existing `--output` file |
+| `--jsonl` | Emit one discovered URL per JSON line, followed by a summary |
 | `--client-name` | Set optional `client_name` for request attribution |
 
 ### `tvly research <query>` / `tvly research run <query>`
@@ -363,6 +393,7 @@ automation can distinguish an available release from a supported self-update.
 | `-o` / `--output` | Save JSON (`.json`) or Markdown (`.md`) |
 | `--save` | Save `report.md` and `report.json` under `.tavily/research/` |
 | `--force` | Overwrite existing output files |
+| `--jsonl` | Emit one streaming event per line (or one final non-stream result) |
 | `--client-name` | Set optional `client_name` for request attribution |
 
 ### `tvly research status`

--- a/tavily_cli/commands/auth.py
+++ b/tavily_cli/commands/auth.py
@@ -139,12 +139,14 @@ def _print_login_success(method: str, detail: str, *, json_mode: bool) -> None:
 
 def _print_login_failure(message: str, *, json_mode: bool) -> None:
     if json_mode:
-        import json as json_mod
+        from tavily_cli.common import emit_error
 
-        click.echo(json_mod.dumps({
-            "authenticated": False,
-            "error": message,
-        }))
+        emit_error(
+            "authentication_failed",
+            message,
+            stage="auth",
+            retryable=False,
+        )
         return
 
     from rich.markup import escape
@@ -212,8 +214,15 @@ def logout(ctx: click.Context, json_flag: bool) -> None:
         if json_mode:
             import json as json_mod
 
+            from tavily_cli.common import error_payload
+
             payload["server_revoked"] = False
-            payload["error"] = result.revocation_error
+            payload.update(error_payload(
+                "oauth_revocation_failed",
+                result.revocation_error,
+                stage="auth",
+                retryable=True,
+            ))
             click.echo(json_mod.dumps(payload))
         else:
             from rich.markup import escape

--- a/tavily_cli/commands/crawl.py
+++ b/tavily_cli/commands/crawl.py
@@ -25,6 +25,7 @@ from tavily_cli.common import client_name_option, handle_api_error, json_option
 @click.option("--timeout", type=float, default=None, help="Max wait time in seconds (10-150).")
 @click.option("--output", "-o", "output_file", default=None, help="Save JSON output to file.")
 @click.option("--output-dir", default=None, help="Save each page as a .md file in this directory.")
+@click.option("--jsonl", is_flag=True, default=False, help="Output one crawled page per JSON line.")
 @client_name_option
 @json_option
 def crawl(
@@ -45,6 +46,7 @@ def crawl(
     timeout: float | None,
     output_file: str | None,
     output_dir: str | None,
+    jsonl: bool,
     client_name: str | None,
     json_output: bool,
 ) -> None:
@@ -57,8 +59,14 @@ def crawl(
     from tavily_cli.config import get_client, require_api_key_friendly
     from tavily_cli.output import print_crawl_results
 
-    require_api_key_friendly("crawl", json_mode=json_output)
-    client = get_client(client_name=client_name, json_mode=json_output)
+    if json_output and jsonl:
+        raise click.UsageError("Use either --json or --jsonl, not both.")
+    if jsonl and output_dir:
+        raise click.UsageError("--jsonl cannot be combined with --output-dir; use --output FILE.jsonl.")
+    machine_mode = json_output or jsonl
+
+    require_api_key_friendly("crawl", json_mode=machine_mode)
+    client = get_client(client_name=client_name, json_mode=machine_mode)
 
     kwargs: dict = {"url": url}
     if max_depth is not None:
@@ -93,9 +101,15 @@ def crawl(
     from tavily_cli.theme import spinner
 
     try:
-        with spinner(f"Crawling {url}...", json_mode=json_output):
+        with spinner(f"Crawling {url}...", json_mode=machine_mode):
             response = client.crawl(**kwargs)
     except Exception as e:
-        handle_api_error(e, json_output)
+        handle_api_error(e, machine_mode)
 
-    print_crawl_results(response, json_mode=json_output, output_file=output_file, output_dir=output_dir)
+    print_crawl_results(
+        response,
+        json_mode=json_output,
+        jsonl_mode=jsonl,
+        output_file=output_file,
+        output_dir=output_dir,
+    )

--- a/tavily_cli/commands/extract.py
+++ b/tavily_cli/commands/extract.py
@@ -7,6 +7,7 @@ from tavily import TavilyKeylessLimitError
 
 from tavily_cli.common import (
     client_name_option,
+    error_payload,
     handle_api_error,
     handle_keyless_cap_hit,
     handle_oauth_refresh_error,
@@ -25,6 +26,8 @@ from tavily_cli.common import (
 @click.option("--output", "-o", "output_file", default=None, help="Save as JSON (.json) or Markdown (.md).")
 @click.option("--save", is_flag=True, default=False, help="Save JSON under .tavily/extract/.")
 @click.option("--force", is_flag=True, default=False, help="Overwrite an existing output file.")
+@click.option("--fail-on-partial", is_flag=True, default=False, help="Exit nonzero if any URL fails.")
+@click.option("--jsonl", is_flag=True, default=False, help="Output one extraction record per JSON line.")
 @client_name_option
 @json_option
 def extract(
@@ -38,6 +41,8 @@ def extract(
     output_file: str | None,
     save: bool,
     force: bool,
+    fail_on_partial: bool,
+    jsonl: bool,
     client_name: str | None,
     json_output: bool,
 ) -> None:
@@ -50,6 +55,9 @@ def extract(
     """
     from tavily_cli.config import get_client_or_keyless
     from tavily_cli.output import print_extract_results, validate_artifact_options
+
+    if json_output and jsonl:
+        raise click.UsageError("Use either --json or --jsonl, not both.")
 
     validate_artifact_options(
         output_file=output_file,
@@ -80,19 +88,36 @@ def extract(
 
     try:
         client, _is_keyless = get_client_or_keyless(client_name=client_name)
-        with spinner(f"Extracting {len(url_list)} URL{'s' if len(url_list) > 1 else ''}...", json_mode=json_output):
+        with spinner(
+            f"Extracting {len(url_list)} URL{'s' if len(url_list) > 1 else ''}...",
+            json_mode=json_output or jsonl,
+        ):
             response = client.extract(**kwargs)
     except TavilyKeylessLimitError as e:
-        handle_keyless_cap_hit(e, json_output)
+        handle_keyless_cap_hit(e, json_output or jsonl)
     except OAuthError as e:
-        handle_oauth_refresh_error(e, json_output)
+        handle_oauth_refresh_error(e, json_output or jsonl)
     except Exception as e:
-        handle_api_error(e, json_output)
+        handle_api_error(e, json_output or jsonl)
+
+    failed = response.get("failed_results") or []
+    failure = None
+    if fail_on_partial and failed:
+        failure = error_payload(
+            "extract_partial_failure",
+            f"{len(failed)} URL{'s' if len(failed) != 1 else ''} failed to extract.",
+            stage="extract",
+            retryable=False,
+        )
 
     print_extract_results(
         response,
         json_mode=json_output,
+        jsonl_mode=jsonl,
         output_file=output_file,
         save=save,
         force=force,
+        failure=failure,
     )
+    if failure:
+        raise click.exceptions.Exit(5)

--- a/tavily_cli/commands/init.py
+++ b/tavily_cli/commands/init.py
@@ -11,7 +11,7 @@ from typing import Any
 import click
 
 from tavily_cli import __version__
-from tavily_cli.common import json_option
+from tavily_cli.common import error_payload, json_option
 from tavily_cli.init_skills import (
     SKILLS_SOURCE,
     agent_specs,
@@ -212,7 +212,18 @@ def _empty_result(agents: tuple[str, ...]) -> dict[str, Any]:
 
 
 def _fail(result: dict[str, Any], stage: str, message: str, exit_code: int, json_output: bool) -> None:
-    result["error"] = {"stage": stage, "message": message}
+    code = {
+        "auth": "initialization_auth_failed",
+        "skills": "initialization_skills_failed",
+        "cli": "initialization_cli_failed",
+        "live_search": "initialization_verification_failed",
+    }.get(stage, "initialization_failed")
+    result.update(error_payload(
+        code,
+        message,
+        stage=stage,
+        retryable=stage == "live_search",
+    ))
     _print_result(result, json_output=json_output)
     raise click.exceptions.Exit(exit_code)
 

--- a/tavily_cli/commands/map_cmd.py
+++ b/tavily_cli/commands/map_cmd.py
@@ -22,6 +22,7 @@ from tavily_cli.common import client_name_option, handle_api_error, json_option
 @click.option("--output", "-o", "output_file", default=None, help="Save as JSON (.json) or Markdown (.md).")
 @click.option("--save", is_flag=True, default=False, help="Save JSON under .tavily/map/.")
 @click.option("--force", is_flag=True, default=False, help="Overwrite an existing output file.")
+@click.option("--jsonl", is_flag=True, default=False, help="Output one discovered URL per JSON line.")
 @client_name_option
 @json_option
 def map_urls(
@@ -39,6 +40,7 @@ def map_urls(
     output_file: str | None,
     save: bool,
     force: bool,
+    jsonl: bool,
     client_name: str | None,
     json_output: bool,
 ) -> None:
@@ -51,14 +53,18 @@ def map_urls(
     from tavily_cli.config import get_client, require_api_key_friendly
     from tavily_cli.output import print_map_results, validate_artifact_options
 
+    if json_output and jsonl:
+        raise click.UsageError("Use either --json or --jsonl, not both.")
+    machine_mode = json_output or jsonl
+
     validate_artifact_options(
         output_file=output_file,
         save=save,
         force=force,
     )
 
-    require_api_key_friendly("map", json_mode=json_output)
-    client = get_client(client_name=client_name, json_mode=json_output)
+    require_api_key_friendly("map", json_mode=machine_mode)
+    client = get_client(client_name=client_name, json_mode=machine_mode)
 
     kwargs: dict = {"url": url}
     if max_depth is not None:
@@ -85,14 +91,15 @@ def map_urls(
     from tavily_cli.theme import spinner
 
     try:
-        with spinner(f"Mapping {url}...", json_mode=json_output):
+        with spinner(f"Mapping {url}...", json_mode=machine_mode):
             response = client.map(**kwargs)
     except Exception as e:
-        handle_api_error(e, json_output)
+        handle_api_error(e, machine_mode)
 
     print_map_results(
         response,
         json_mode=json_output,
+        jsonl_mode=jsonl,
         output_file=output_file,
         save=save,
         force=force,

--- a/tavily_cli/commands/research.py
+++ b/tavily_cli/commands/research.py
@@ -9,7 +9,7 @@ import time
 import click
 from rich.markup import escape
 
-from tavily_cli.common import client_name_option, handle_api_error, sanitize_control
+from tavily_cli.common import client_name_option, emit_error, handle_api_error, sanitize_control
 
 
 class ResearchGroup(click.Group):
@@ -58,6 +58,78 @@ def _resolve_json(ctx: click.Context, local_flag: bool) -> bool:
     return False
 
 
+def _research_failure_message(response: dict) -> str:
+    error = response.get("error")
+    if isinstance(error, dict):
+        return str(error.get("message") or error.get("detail") or "Research task failed.")
+    return str(error or response.get("detail") or "Research task failed.")
+
+
+def _fail_research(
+    response: dict,
+    *,
+    code: str,
+    stage: str,
+    retryable: bool,
+    request_id: str | None,
+    machine_mode: bool,
+) -> None:
+    """Emit one stable failure and terminate research with an operational error."""
+    message = _research_failure_message(response)
+    if machine_mode:
+        emit_error(
+            code,
+            message,
+            stage=stage,
+            retryable=retryable,
+            request_id=request_id,
+        )
+    else:
+        from tavily_cli.theme import err_console
+
+        err_console.print(f"  [#FAA2FB]> Research failed:[/#FAA2FB] {escape(sanitize_control(message))}")
+    raise click.exceptions.Exit(4)
+
+
+def _stream_json_events(stream_resp):
+    """Parse SSE data events into records suitable for explicit JSONL output."""
+    for chunk in stream_resp:
+        text = chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
+        for line in text.splitlines():
+            if not line.startswith("data:"):
+                continue
+            payload = line[5:].strip()
+            if not payload:
+                continue
+            try:
+                event = json.loads(payload)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if isinstance(event, dict):
+                yield event
+                if event.get("object") == "error" or event.get("error"):
+                    error = event.get("error")
+                    if isinstance(error, dict):
+                        error = error.get("message") or error.get("detail") or error
+                    raise RuntimeError(str(error or "Research stream failed."))
+
+
+def _emit_research_jsonl(records, *, output_file: str | None, force: bool) -> None:
+    """Stream JSONL to stdout, or atomically write it and report the path."""
+    from tavily_cli.output import emit_jsonl
+
+    if output_file:
+        emit_jsonl(list(records), output_file=output_file, force=force)
+        click.echo(json.dumps({
+            "ok": True,
+            "saved": True,
+            "artifacts": [output_file],
+        }, ensure_ascii=False))
+        return
+    for record in records:
+        click.echo(json.dumps(record, ensure_ascii=False))
+
+
 def _render_stream(
     stream_resp,
     *,
@@ -85,6 +157,12 @@ def _render_stream(
             except (json.JSONDecodeError, TypeError):
                 continue
 
+            if data.get("object") == "error" or data.get("error"):
+                error = data.get("error")
+                if isinstance(error, dict):
+                    error = error.get("message") or error.get("detail") or error
+                raise RuntimeError(str(error or "Research stream failed."))
+
             delta = (data.get("choices") or [{}])[0].get("delta", {})
 
             # --- Tool calls: show live status updates ---
@@ -108,8 +186,10 @@ def _render_stream(
 
             # --- Content: collect the report text ---
             content = delta.get("content")
-            if content:
+            if isinstance(content, str) and content:
                 content_parts.append(content)
+            elif content is not None:
+                content_parts = [content]
 
             # --- Sources: collect final source list ---
             src_list = delta.get("sources")
@@ -117,7 +197,11 @@ def _render_stream(
                 sources = src_list
 
     # Render using the same formatter as non-stream output.
-    full_content = "".join(content_parts)
+    full_content = (
+        content_parts[0]
+        if len(content_parts) == 1 and not isinstance(content_parts[0], str)
+        else "".join(content_parts)
+    )
     result = {
         "status": "completed",
         "content": full_content,
@@ -145,6 +229,7 @@ def _render_stream(
 @click.option("--poll-interval", type=int, default=10, help="Seconds between status checks (default: 10).")
 @click.option("--timeout", type=int, default=600, help="Max seconds to wait (default: 600).")
 @click.option("--json", "json_flag", is_flag=True, default=False, help="Output as JSON.")
+@click.option("--jsonl", is_flag=True, default=False, help="Output one streaming event per JSON line.")
 @client_name_option
 @click.pass_context
 def run(
@@ -161,6 +246,7 @@ def run(
     poll_interval: int,
     timeout: int,
     json_flag: bool,
+    jsonl: bool,
     client_name: str | None,
 ) -> None:
     """Start a research task.
@@ -175,6 +261,11 @@ def run(
     from tavily_cli.output import emit, print_research_result, validate_artifact_options
 
     json_mode = _resolve_json(ctx, json_flag)
+    if json_mode and jsonl:
+        raise click.UsageError("Use either --json or --jsonl, not both.")
+    if jsonl and save:
+        raise click.UsageError("--jsonl cannot be combined with --save; use --output FILE.jsonl.")
+    machine_mode = json_mode or jsonl
 
     if query == "-":
         query = sys.stdin.read(100_000).strip()
@@ -187,13 +278,36 @@ def run(
         force=force,
     )
 
-    require_api_key_friendly("research", json_mode=json_mode)
-    client = get_client(client_name=client_name, json_mode=json_mode)
-
     schema = None
     if output_schema:
-        with open(output_schema) as f:
-            schema = json.load(f)
+        try:
+            with open(output_schema, encoding="utf-8") as f:
+                schema = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            message = f"Could not load output schema: {e}"
+            if machine_mode:
+                emit_error(
+                    "invalid_output_schema",
+                    message,
+                    stage="validation",
+                    retryable=False,
+                )
+                raise click.exceptions.Exit(2) from e
+            raise click.UsageError(message) from e
+        if not isinstance(schema, dict) or not isinstance(schema.get("properties"), dict):
+            message = "Output schema must be a JSON object containing a properties object."
+            if machine_mode:
+                emit_error(
+                    "invalid_output_schema",
+                    message,
+                    stage="validation",
+                    retryable=False,
+                )
+                raise click.exceptions.Exit(2)
+            raise click.UsageError(message)
+
+    require_api_key_friendly("research", json_mode=machine_mode)
+    client = get_client(client_name=client_name, json_mode=machine_mode)
 
     kwargs: dict = {"input": query}
     if model is not None:
@@ -209,25 +323,12 @@ def run(
         kwargs["stream"] = True
         try:
             stream_resp = client.research(**kwargs)
-            if json_mode and not (output_file or save):
-                # Re-serialize each SSE event as one JSON line (NDJSON) rather
-                # than forwarding raw SSE bytes: this keeps the output valid,
-                # machine-parseable JSON and lets json.dumps escape any control
-                # characters in server content (raw bytes would otherwise reach
-                # the terminal as escape sequences).
-                for chunk in stream_resp:
-                    text = chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
-                    for line in text.splitlines():
-                        if not line.startswith("data:"):
-                            continue
-                        payload = line[5:].strip()
-                        if not payload:
-                            continue
-                        try:
-                            event = json.loads(payload)
-                        except (json.JSONDecodeError, TypeError):
-                            continue
-                        click.echo(json.dumps(event, ensure_ascii=False))
+            if jsonl:
+                _emit_research_jsonl(
+                    _stream_json_events(stream_resp),
+                    output_file=output_file,
+                    force=force,
+                )
             else:
                 _render_stream(
                     stream_resp,
@@ -239,18 +340,30 @@ def run(
         except click.ClickException:
             raise
         except Exception as e:
-            handle_api_error(e, json_mode)
+            handle_api_error(e, machine_mode, stage="stream", retryable=True)
         return
 
     try:
-        with spinner("Starting research...", json_mode=json_mode):
+        with spinner("Starting research...", json_mode=machine_mode):
             result = client.research(**kwargs)
     except Exception as e:
-        handle_api_error(e, json_mode)
+        handle_api_error(e, machine_mode, stage="submit")
 
     # If the initial response is already complete (e.g., MCP endpoint returns
     # the full result synchronously), skip polling entirely.
     if result.get("status") in ("completed", "failed") or result.get("content"):
+        if result.get("status") == "failed":
+            _fail_research(
+                result,
+                code="research_failed",
+                stage="submit",
+                retryable=False,
+                request_id=result.get("request_id"),
+                machine_mode=machine_mode,
+            )
+        if jsonl:
+            _emit_research_jsonl([result], output_file=output_file, force=force)
+            return
         print_research_result(
             result,
             json_mode=json_mode,
@@ -263,10 +376,13 @@ def run(
     request_id = result.get("request_id")
     if not request_id:
         # No request_id and not complete — unexpected response.
-        handle_api_error(RuntimeError(f"Unexpected API response: {result}"), json_mode)
+        handle_api_error(RuntimeError(f"Unexpected API response: {result}"), machine_mode, stage="submit")
 
     if no_wait:
         pending_result = {"request_id": request_id, "status": result.get("status", "pending")}
+        if jsonl:
+            _emit_research_jsonl([pending_result], output_file=output_file, force=force)
+            return
         if output_file or save:
             print_research_result(
                 pending_result,
@@ -281,30 +397,26 @@ def run(
 
     elapsed = 0
     response = result
-    if json_mode:
-        # JSON mode: poll silently
+    if machine_mode:
+        # Machine modes: poll silently.
         while elapsed < timeout:
             try:
                 response = client.get_research(request_id)
             except Exception as e:
-                handle_api_error(e, json_mode)
+                handle_api_error(e, machine_mode, stage="poll", retryable=True, request_id=request_id)
             if response.get("status") in ("completed", "failed"):
                 break
             time.sleep(poll_interval)
             elapsed += poll_interval
         else:
-            timeout_result = {"request_id": request_id, "status": "timeout"}
-            if output_file or save:
-                print_research_result(
-                    timeout_result,
-                    json_mode=json_mode,
-                    output_file=output_file,
-                    save=save,
-                    force=force,
-                )
-            else:
-                emit(timeout_result, json_mode=True)
-            return
+            _fail_research(
+                {"error": f"Research timed out after {timeout}s."},
+                code="research_timeout",
+                stage="poll",
+                retryable=True,
+                request_id=request_id,
+                machine_mode=True,
+            )
     else:
         # Rich mode: live spinner with running elapsed time
         with err_console.status("", spinner="dots") as live:
@@ -315,7 +427,7 @@ def run(
                     try:
                         response = client.get_research(request_id)
                     except Exception as e:
-                        handle_api_error(e, json_mode)
+                        handle_api_error(e, json_mode, stage="poll", retryable=True, request_id=request_id)
                     if response.get("status", "unknown") in ("completed", "failed"):
                         break
                     next_poll = elapsed + poll_interval
@@ -323,15 +435,28 @@ def run(
                 elapsed += 1
             else:
                 err_console.print(f"[#FFC769]Timed out after {timeout}s. Resume with: tvly research poll {escape(sanitize_control(request_id))}[/#FFC769]")
-                if output_file or save:
-                    print_research_result(
-                        {"request_id": request_id, "status": "timeout"},
-                        json_mode=json_mode,
-                        output_file=output_file,
-                        save=save,
-                        force=force,
-                    )
-                return
+                _fail_research(
+                    {"error": f"Research timed out after {timeout}s."},
+                    code="research_timeout",
+                    stage="poll",
+                    retryable=True,
+                    request_id=request_id,
+                    machine_mode=False,
+                )
+
+    if response.get("status") == "failed":
+        _fail_research(
+            response,
+            code="research_failed",
+            stage="poll",
+            retryable=False,
+            request_id=request_id,
+            machine_mode=machine_mode,
+        )
+
+    if jsonl:
+        _emit_research_jsonl([response], output_file=output_file, force=force)
+        return
 
     print_research_result(
         response,
@@ -359,7 +484,17 @@ def status(ctx: click.Context, request_id: str, json_flag: bool, client_name: st
     try:
         response = client.get_research(request_id)
     except Exception as e:
-        handle_api_error(e, json_mode)
+        handle_api_error(e, json_mode, stage="status", retryable=True, request_id=request_id)
+
+    if response.get("status") == "failed":
+        _fail_research(
+            response,
+            code="research_failed",
+            stage="status",
+            retryable=False,
+            request_id=request_id,
+            machine_mode=json_mode,
+        )
 
     if json_mode:
         emit(response, json_mode=True)
@@ -399,7 +534,7 @@ def poll(
 ) -> None:
     """Poll a research task until completion and return results."""
     from tavily_cli.config import get_client, require_api_key_friendly
-    from tavily_cli.output import emit, print_research_result, validate_artifact_options
+    from tavily_cli.output import print_research_result, validate_artifact_options
     from tavily_cli.theme import err_console
 
     json_mode = _resolve_json(ctx, json_flag)
@@ -418,24 +553,20 @@ def poll(
             try:
                 response = client.get_research(request_id)
             except Exception as e:
-                handle_api_error(e, json_mode)
+                handle_api_error(e, json_mode, stage="poll", retryable=True, request_id=request_id)
             if response.get("status") in ("completed", "failed"):
                 break
             time.sleep(poll_interval)
             elapsed += poll_interval
         else:
-            timeout_result = {"request_id": request_id, "status": "timeout"}
-            if output_file or save:
-                print_research_result(
-                    timeout_result,
-                    json_mode=json_mode,
-                    output_file=output_file,
-                    save=save,
-                    force=force,
-                )
-            else:
-                emit(timeout_result, json_mode=True)
-            return
+            _fail_research(
+                {"error": f"Research timed out after {timeout}s."},
+                code="research_timeout",
+                stage="poll",
+                retryable=True,
+                request_id=request_id,
+                machine_mode=True,
+            )
     else:
         with err_console.status("", spinner="dots") as live:
             next_poll = 0
@@ -445,7 +576,7 @@ def poll(
                     try:
                         response = client.get_research(request_id)
                     except Exception as e:
-                        handle_api_error(e, json_mode)
+                        handle_api_error(e, json_mode, stage="poll", retryable=True, request_id=request_id)
                     if response.get("status") in ("completed", "failed"):
                         break
                     next_poll = elapsed + poll_interval
@@ -453,15 +584,24 @@ def poll(
                 elapsed += 1
             else:
                 err_console.print(f"[#FFC769]Timed out after {timeout}s.[/#FFC769]")
-                if output_file or save:
-                    print_research_result(
-                        {"request_id": request_id, "status": "timeout"},
-                        json_mode=json_mode,
-                        output_file=output_file,
-                        save=save,
-                        force=force,
-                    )
-                return
+                _fail_research(
+                    {"error": f"Research timed out after {timeout}s."},
+                    code="research_timeout",
+                    stage="poll",
+                    retryable=True,
+                    request_id=request_id,
+                    machine_mode=False,
+                )
+
+    if response.get("status") == "failed":
+        _fail_research(
+            response,
+            code="research_failed",
+            stage="poll",
+            retryable=False,
+            request_id=request_id,
+            machine_mode=json_mode,
+        )
 
     print_research_result(
         response,

--- a/tavily_cli/commands/search.py
+++ b/tavily_cli/commands/search.py
@@ -35,6 +35,7 @@ from tavily_cli.common import (
 @click.option("--output", "-o", "output_file", default=None, help="Save as JSON (.json) or Markdown (.md).")
 @click.option("--save", is_flag=True, default=False, help="Save JSON under .tavily/search/.")
 @click.option("--force", is_flag=True, default=False, help="Overwrite an existing output file.")
+@click.option("--jsonl", is_flag=True, default=False, help="Output one search result per JSON line.")
 @client_name_option
 @json_option
 def search(
@@ -56,6 +57,7 @@ def search(
     output_file: str | None,
     save: bool,
     force: bool,
+    jsonl: bool,
     client_name: str | None,
     json_output: bool,
 ) -> None:
@@ -68,6 +70,10 @@ def search(
     """
     from tavily_cli.config import get_client_or_keyless
     from tavily_cli.output import print_search_results, validate_artifact_options
+
+    if json_output and jsonl:
+        raise click.UsageError("Use either --json or --jsonl, not both.")
+    machine_mode = json_output or jsonl
 
     if query == "-":
         query = sys.stdin.read(100_000).strip()
@@ -115,18 +121,19 @@ def search(
 
     try:
         client, _is_keyless = get_client_or_keyless(client_name=client_name)
-        with spinner("Searching...", json_mode=json_output):
+        with spinner("Searching...", json_mode=machine_mode):
             response = client.search(**kwargs)
     except TavilyKeylessLimitError as e:
-        handle_keyless_cap_hit(e, json_output)
+        handle_keyless_cap_hit(e, machine_mode)
     except OAuthError as e:
-        handle_oauth_refresh_error(e, json_output)
+        handle_oauth_refresh_error(e, machine_mode)
     except Exception as e:
-        handle_api_error(e, json_output)
+        handle_api_error(e, machine_mode)
 
     print_search_results(
         response,
         json_mode=json_output,
+        jsonl_mode=jsonl,
         output_file=output_file,
         save=save,
         force=force,

--- a/tavily_cli/commands/update.py
+++ b/tavily_cli/commands/update.py
@@ -18,7 +18,7 @@ import httpx
 from packaging.version import InvalidVersion, Version
 
 from tavily_cli import __version__
-from tavily_cli.common import json_option, sanitize_control
+from tavily_cli.common import error_payload, json_option, sanitize_control
 
 PACKAGE_NAME = "tavily-cli"
 PYPI_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
@@ -352,7 +352,18 @@ def _result(*, current: str, latest: str, install: InstallInfo, updated: bool) -
 def _fail(stage: str, message: str, exit_code: int, json_output: bool) -> None:
     safe_message = sanitize_control(message)
     if json_output:
-        click.echo(json.dumps({"ok": False, "error": {"stage": stage, "message": safe_message}}, sort_keys=True))
+        code = {
+            "check": "update_check_failed",
+            "install_method": "update_unsupported_install",
+            "update": "update_failed",
+            "verify": "update_verification_failed",
+        }.get(stage, "update_failed")
+        click.echo(json.dumps(error_payload(
+            code,
+            safe_message,
+            stage=stage,
+            retryable=stage in {"check", "update"},
+        ), sort_keys=True))
     else:
         from rich.markup import escape
 

--- a/tavily_cli/common.py
+++ b/tavily_cli/common.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import functools
 import json
 import re
+from typing import Any
 
 import click
 from tavily import TavilyKeylessLimitError
@@ -39,18 +40,65 @@ class TavilyAPIError(Exception):
         self.docs = docs
 
 
+def error_payload(
+    code: str,
+    message: object,
+    *,
+    stage: str,
+    retryable: bool,
+    request_id: str | None = None,
+    **details: Any,
+) -> dict[str, Any]:
+    """Build the stable machine-readable failure envelope."""
+    error: dict[str, Any] = {
+        "code": code,
+        "message": sanitize_control(message),
+        "stage": stage,
+        "retryable": retryable,
+    }
+    if request_id:
+        error["request_id"] = request_id
+    error.update({key: value for key, value in details.items() if value is not None})
+    return {"ok": False, "error": error}
+
+
+def emit_error(
+    code: str,
+    message: object,
+    *,
+    stage: str,
+    retryable: bool,
+    request_id: str | None = None,
+    **details: Any,
+) -> None:
+    """Write one stable error document to stdout."""
+    click.echo(
+        json.dumps(
+            error_payload(
+                code,
+                message,
+                stage=stage,
+                retryable=retryable,
+                request_id=request_id,
+                **details,
+            ),
+            ensure_ascii=False,
+        )
+    )
+
+
 def handle_keyless_cap_hit(e: TavilyKeylessLimitError, json_mode: bool) -> None:
     """Render a keyless rate-limit cap-hit and exit non-zero."""
     if json_mode:
-        click.echo(json.dumps({
-            "error": {
-                "code": e.code,
-                "message": e.message,
-                "window": e.window,
-                "retry_after_seconds": e.retry_after_seconds,
-                "next_actions": e.next_actions,
-            }
-        }))
+        emit_error(
+            e.code,
+            e.message,
+            stage="request",
+            retryable=e.retry_after_seconds is not None,
+            window=e.window,
+            retry_after_seconds=e.retry_after_seconds,
+            next_actions=e.next_actions,
+        )
         raise SystemExit(3)
 
     from tavily_cli.theme import err_console
@@ -81,12 +129,12 @@ def handle_oauth_refresh_error(e: Exception, json_mode: bool) -> None:
     """Render a stored OAuth refresh failure without treating it as logout."""
     message = sanitize_control(e)
     if json_mode:
-        click.echo(json.dumps({
-            "error": {
-                "code": "oauth_refresh_failed",
-                "message": message,
-            }
-        }))
+        emit_error(
+            "oauth_refresh_failed",
+            message,
+            stage="auth",
+            retryable=True,
+        )
         raise SystemExit(3)
 
     from rich.markup import escape
@@ -124,11 +172,38 @@ def client_name_option(func):
 _LIMIT_STATUSES = {429, 432}
 
 
-def handle_api_error(e: Exception, json_mode: bool) -> None:
+def handle_api_error(
+    e: Exception,
+    json_mode: bool,
+    *,
+    code: str | None = None,
+    stage: str = "request",
+    retryable: bool | None = None,
+    request_id: str | None = None,
+) -> None:
     """Print an API error and exit."""
+    status = e.status if isinstance(e, TavilyAPIError) else None
+    is_limit = status in _LIMIT_STATUSES
+    if code is None:
+        if status == 401:
+            code = "authentication_failed"
+        elif is_limit:
+            code = "api_limit_reached"
+        else:
+            code = "api_error"
+    if retryable is None:
+        retryable = status == 429
+
     if json_mode:
-        click.echo(json.dumps({"error": str(e)}))
-        raise SystemExit(4)
+        emit_error(
+            code,
+            e,
+            stage=stage,
+            retryable=retryable,
+            request_id=request_id,
+            status=status,
+        )
+        raise SystemExit(3 if is_limit else 4)
 
     from urllib.parse import urlparse
 
@@ -138,7 +213,7 @@ def handle_api_error(e: Exception, json_mode: bool) -> None:
 
     message = escape(sanitize_control(e))
 
-    if isinstance(e, TavilyAPIError) and e.status in _LIMIT_STATUSES:
+    if isinstance(e, TavilyAPIError) and is_limit:
         err_console.print()
         err_console.print(f"  [#FFC769]>[/#FFC769] {message}")
         err_console.print()

--- a/tavily_cli/config.py
+++ b/tavily_cli/config.py
@@ -512,6 +512,16 @@ def get_api_key_or_exit(*, json_mode: bool = False) -> str:
 
         handle_oauth_refresh_error(e, json_mode)
     if not key:
+        if json_mode:
+            from tavily_cli.common import emit_error
+
+            emit_error(
+                "authentication_required",
+                "No Tavily API key found.",
+                stage="auth",
+                retryable=False,
+            )
+            sys.exit(3)
         from rich.console import Console
         console = Console(stderr=True)
         console.print("  [#FAA2FB]> Error:[/#FAA2FB] No Tavily API key found.")
@@ -586,6 +596,17 @@ def require_api_key_friendly(command_name: str, *, json_mode: bool = False) -> s
         handle_oauth_refresh_error(e, json_mode)
     if key:
         return key
+
+    if json_mode:
+        from tavily_cli.common import emit_error
+
+        emit_error(
+            "authentication_required",
+            f"The {command_name} command requires authentication.",
+            stage="auth",
+            retryable=False,
+        )
+        sys.exit(3)
 
     from rich.console import Console
     console = Console(stderr=True)

--- a/tavily_cli/mcp_client.py
+++ b/tavily_cli/mcp_client.py
@@ -18,7 +18,23 @@ MCP_URL = "https://mcp.tavily.com/mcp"
 
 def _raise_if_api_error(parsed: dict) -> None:
     """Raise TavilyAPIError if the parsed response contains an error."""
-    if not isinstance(parsed, dict) or "error" not in parsed:
+    if not isinstance(parsed, dict):
+        return
+    if (
+        isinstance(parsed.get("code"), str)
+        and isinstance(parsed.get("message"), str)
+        and parsed.get("auth_mode") == "keyless"
+    ):
+        from tavily import TavilyKeylessLimitError
+
+        raise TavilyKeylessLimitError(
+            parsed["message"],
+            code=parsed["code"],
+            window=parsed.get("window"),
+            retry_after_seconds=parsed.get("retry_after_seconds"),
+            next_actions=parsed.get("next_actions"),
+        )
+    if "error" not in parsed or parsed.get("status") == "failed":
         return
     from tavily_cli.common import TavilyAPIError
     detail = parsed.get("detail", {})

--- a/tavily_cli/output.py
+++ b/tavily_cli/output.py
@@ -234,6 +234,53 @@ def emit(
         click.echo(text, nl=False)
 
 
+def emit_jsonl(
+    records: list[Any],
+    *,
+    output_file: str | None = None,
+    force: bool = True,
+    create_parents: bool = False,
+) -> None:
+    """Write one compact JSON value per line to stdout or an artifact."""
+    text = "".join(_json_text(record, pretty=False) for record in records)
+    if output_file:
+        _atomic_write_text(Path(output_file), text, force=force, create_parents=create_parents)
+    else:
+        click.echo(text, nl=False)
+
+
+def _emit_result_jsonl(
+    data: dict,
+    *,
+    command: str,
+    result_type: str,
+    output_file: str | None,
+    save: bool = False,
+    force: bool = True,
+) -> None:
+    """Emit list-shaped API output as typed records followed by metadata."""
+    results = data.get("results") or []
+    records = [{"type": result_type, "data": result} for result in results]
+    records.append({
+        "type": "summary",
+        "data": {
+            **{key: value for key, value in data.items() if key != "results"},
+            "result_count": len(results),
+        },
+    })
+
+    path = output_file
+    if save:
+        path = str(Path(".tavily") / command / f"{_artifact_timestamp()}.jsonl")
+    emit_jsonl(records, output_file=path, force=force, create_parents=save)
+    if path:
+        click.echo(json.dumps({
+            "ok": True,
+            "saved": True,
+            "artifacts": [path],
+        }, ensure_ascii=False))
+
+
 def _one_line(value: Any) -> str:
     return " ".join(sanitize_control(value).splitlines()).strip()
 
@@ -362,11 +409,22 @@ def print_search_results(
     data: dict,
     *,
     json_mode: bool,
+    jsonl_mode: bool = False,
     output_file: str | None = None,
     save: bool = False,
     force: bool = False,
 ) -> None:
     results = data.get("results") or []
+    if jsonl_mode:
+        _emit_result_jsonl(
+            data,
+            command="search",
+            result_type="result",
+            output_file=output_file,
+            save=save,
+            force=force,
+        )
+        return
     if _save_result(
         data,
         command="search",
@@ -444,12 +502,75 @@ def print_extract_results(
     data: dict,
     *,
     json_mode: bool,
+    jsonl_mode: bool = False,
     output_file: str | None = None,
     save: bool = False,
     force: bool = False,
+    failure: dict[str, Any] | None = None,
 ) -> None:
     results = data.get("results") or []
     failed = data.get("failed_results") or []
+    if jsonl_mode:
+        records = [
+            {"type": "result", "data": result}
+            for result in results
+        ]
+        records.extend(
+            {"type": "failed_result", "data": failed_result}
+            for failed_result in failed
+        )
+        metadata = {
+            key: value
+            for key, value in data.items()
+            if key not in {"results", "failed_results"}
+        }
+        records.append({
+            "type": "summary",
+            "data": {
+                **metadata,
+                "result_count": len(results),
+                "failed_count": len(failed),
+            },
+        })
+        if failure:
+            records.append(failure)
+
+        path = output_file
+        if save:
+            path = str(Path(".tavily") / "extract" / f"{_artifact_timestamp()}.jsonl")
+        if path:
+            emit_jsonl(records, output_file=path, force=force, create_parents=save)
+            payload = failure.copy() if failure else {"ok": True}
+            payload.update({
+                "saved": True,
+                "summary": f"Saved {len(results)} extraction{'s' if len(results) != 1 else ''} ({len(failed)} failed).",
+                "artifacts": [path],
+            })
+            click.echo(json.dumps(payload, ensure_ascii=False))
+        else:
+            emit_jsonl(records)
+        return
+
+    if failure and json_mode:
+        payload = failure.copy()
+        if output_file or save:
+            path = Path(output_file) if output_file else Path(".tavily") / "extract" / f"{_artifact_timestamp()}.json"
+            _atomic_write_text(
+                path,
+                _json_text(data, pretty=True),
+                force=force,
+                create_parents=save,
+            )
+            payload.update({
+                "saved": True,
+                "summary": f"Saved {len(results)} extraction{'s' if len(results) != 1 else ''} ({len(failed)} failed).",
+                "artifacts": [str(path)],
+            })
+        else:
+            payload["data"] = data
+        emit(payload, json_mode=True)
+        return
+
     if _save_result(
         data,
         command="extract",
@@ -508,9 +629,18 @@ def print_crawl_results(
     data: dict,
     *,
     json_mode: bool,
+    jsonl_mode: bool = False,
     output_file: str | None = None,
     output_dir: str | None = None,
 ) -> None:
+    if jsonl_mode:
+        _emit_result_jsonl(
+            data,
+            command="crawl",
+            result_type="page",
+            output_file=output_file,
+        )
+        return
     if output_dir:
         _save_crawl_to_dir(data, output_dir)
         return
@@ -587,11 +717,22 @@ def print_map_results(
     data: dict,
     *,
     json_mode: bool,
+    jsonl_mode: bool = False,
     output_file: str | None = None,
     save: bool = False,
     force: bool = False,
 ) -> None:
     results = data.get("results") or []
+    if jsonl_mode:
+        _emit_result_jsonl(
+            data,
+            command="map",
+            result_type="url",
+            output_file=output_file,
+            save=save,
+            force=force,
+        )
+        return
     if _save_result(
         data,
         command="map",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -199,7 +199,9 @@ def test_init_noninteractive_auth_failure_is_json(monkeypatch: pytest.MonkeyPatc
     assert result.exit_code == 3
     output = json.loads(result.stdout)
     assert output["ok"] is False
+    assert output["error"]["code"] == "initialization_auth_failed"
     assert output["error"]["stage"] == "auth"
+    assert output["error"]["retryable"] is False
     assert output["skills"]["skipped"] is True
 
 
@@ -214,4 +216,6 @@ def test_init_live_search_failure_exits_four(monkeypatch: pytest.MonkeyPatch) ->
 
     assert result.exit_code == 4
     output = json.loads(result.stdout)
+    assert output["error"]["code"] == "initialization_verification_failed"
     assert output["error"]["stage"] == "live_search"
+    assert output["error"]["retryable"] is True

--- a/tests/test_machine_contract.py
+++ b/tests/test_machine_contract.py
@@ -1,0 +1,359 @@
+"""Stable machine output, failure exits, and explicit JSONL behavior."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+from tavily import TavilyKeylessLimitError
+
+from tavily_cli.cli import cli
+
+
+class FakeResearchClient:
+    def __init__(self, initial: dict, polled: dict | None = None) -> None:
+        self.initial = initial
+        self.polled = polled or initial
+        self.research_kwargs: dict | None = None
+
+    def research(self, **kwargs):
+        self.research_kwargs = kwargs
+        return self.initial
+
+    def get_research(self, request_id: str):
+        return self.polled
+
+
+def _install_research_client(monkeypatch: pytest.MonkeyPatch, client: FakeResearchClient) -> None:
+    monkeypatch.setattr("tavily_cli.config.require_api_key_friendly", lambda *args, **kwargs: "token")
+    monkeypatch.setattr("tavily_cli.config.get_client", lambda **kwargs: client)
+
+
+def test_research_timeout_is_structured_and_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_research_client(
+        monkeypatch,
+        FakeResearchClient({"request_id": "req-timeout", "status": "pending"}),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["research", "run", "topic", "--timeout", "0", "--json"],
+    )
+
+    assert result.exit_code == 4
+    assert json.loads(result.stdout) == {
+        "ok": False,
+        "error": {
+            "code": "research_timeout",
+            "message": "Research timed out after 0s.",
+            "stage": "poll",
+            "retryable": True,
+            "request_id": "req-timeout",
+        },
+    }
+    assert result.stderr == ""
+
+
+def test_failed_research_is_structured_and_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_research_client(
+        monkeypatch,
+        FakeResearchClient(
+            {
+                "request_id": "req-failed",
+                "status": "failed",
+                "error": "The research agent failed.",
+            }
+        ),
+    )
+
+    result = CliRunner().invoke(cli, ["research", "run", "topic", "--json"])
+
+    assert result.exit_code == 4
+    assert json.loads(result.stdout)["error"] == {
+        "code": "research_failed",
+        "message": "The research agent failed.",
+        "stage": "submit",
+        "retryable": False,
+        "request_id": "req-failed",
+    }
+
+
+def test_research_status_failure_is_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeResearchClient({}, {"status": "failed", "error": "No result"})
+    _install_research_client(monkeypatch, client)
+
+    result = CliRunner().invoke(cli, ["research", "status", "req-status", "--json"])
+
+    assert result.exit_code == 4
+    assert json.loads(result.stdout)["error"]["stage"] == "status"
+    assert json.loads(result.stdout)["error"]["request_id"] == "req-status"
+
+
+def test_invalid_research_schema_is_structured_and_does_not_call_api(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text('{"type":"object"}')
+    monkeypatch.setattr(
+        "tavily_cli.config.get_client",
+        lambda **kwargs: pytest.fail("invalid schemas must fail before client creation"),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["research", "run", "topic", "--output-schema", str(schema_path), "--json"],
+    )
+
+    assert result.exit_code == 2
+    assert json.loads(result.stdout) == {
+        "ok": False,
+        "error": {
+            "code": "invalid_output_schema",
+            "message": "Output schema must be a JSON object containing a properties object.",
+            "stage": "validation",
+            "retryable": False,
+        },
+    }
+
+
+def test_research_schema_is_forwarded_to_client(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schema = {"properties": {"answer": {"type": "string"}}}
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text(json.dumps(schema))
+    client = FakeResearchClient(
+        {"request_id": "req-schema", "status": "completed", "content": {"answer": "done"}}
+    )
+    _install_research_client(monkeypatch, client)
+
+    result = CliRunner().invoke(
+        cli,
+        ["research", "run", "topic", "--output-schema", str(schema_path), "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert client.research_kwargs == {"input": "topic", "output_schema": schema}
+    assert json.loads(result.stdout)["content"] == {"answer": "done"}
+
+
+def test_research_stream_json_is_one_document(monkeypatch: pytest.MonkeyPatch) -> None:
+    chunks = [
+        'data:{"choices":[{"delta":{"content":"hello "}}]}',
+        'data:{"choices":[{"delta":{"content":"world","sources":[{"url":"https://example.com"}]}}]}',
+    ]
+    _install_research_client(monkeypatch, FakeResearchClient(chunks))
+
+    result = CliRunner().invoke(cli, ["research", "run", "topic", "--stream", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {
+        "status": "completed",
+        "content": "hello world",
+        "sources": [{"url": "https://example.com"}],
+    }
+
+
+def test_research_stream_jsonl_is_explicit(monkeypatch: pytest.MonkeyPatch) -> None:
+    events = [
+        {"choices": [{"delta": {"content": "hello"}}]},
+        {"choices": [{"delta": {"content": " world"}}]},
+    ]
+    chunks = [f"data:{json.dumps(event)}" for event in events]
+    _install_research_client(monkeypatch, FakeResearchClient(chunks))
+
+    result = CliRunner().invoke(cli, ["research", "run", "topic", "--stream", "--jsonl"])
+
+    assert result.exit_code == 0, result.output
+    assert [json.loads(line) for line in result.stdout.splitlines()] == events
+
+
+def test_extract_fail_on_partial_json_includes_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    response = {
+        "results": [{"url": "https://good.example", "raw_content": "ok"}],
+        "failed_results": [{"url": "https://bad.example", "error": "blocked"}],
+    }
+
+    class FakeExtractClient:
+        def extract(self, **kwargs):
+            return response
+
+    monkeypatch.setattr(
+        "tavily_cli.config.get_client_or_keyless",
+        lambda **kwargs: (FakeExtractClient(), False),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["extract", "https://good.example", "https://bad.example", "--fail-on-partial", "--json"],
+    )
+
+    assert result.exit_code == 5
+    payload = json.loads(result.stdout)
+    assert payload["error"] == {
+        "code": "extract_partial_failure",
+        "message": "1 URL failed to extract.",
+        "stage": "extract",
+        "retryable": False,
+    }
+    assert payload["data"] == response
+
+
+def test_extract_jsonl_has_records_summary_and_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeExtractClient:
+        def extract(self, **kwargs):
+            return {
+                "results": [{"url": "https://good.example", "raw_content": "ok"}],
+                "failed_results": [{"url": "https://bad.example", "error": "blocked"}],
+                "response_time": 1.2,
+            }
+
+    monkeypatch.setattr(
+        "tavily_cli.config.get_client_or_keyless",
+        lambda **kwargs: (FakeExtractClient(), False),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["extract", "https://good.example", "--fail-on-partial", "--jsonl"],
+    )
+
+    assert result.exit_code == 5
+    records = [json.loads(line) for line in result.stdout.splitlines()]
+    assert [record.get("type") for record in records[:3]] == ["result", "failed_result", "summary"]
+    assert records[-1]["error"]["code"] == "extract_partial_failure"
+
+
+def test_json_and_jsonl_are_mutually_exclusive(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = CliRunner().invoke(
+        cli,
+        ["extract", "https://example.com", "--json", "--jsonl"],
+    )
+
+    assert result.exit_code == 2
+    assert "either --json or --jsonl" in result.stderr
+
+
+def test_keyless_limit_uses_stable_error_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    class LimitedClient:
+        def search(self, **kwargs):
+            raise TavilyKeylessLimitError(
+                "Daily allowance reached.",
+                code="daily_cap_reached",
+                window="day",
+                retry_after_seconds=60,
+                next_actions=[{"action": "login"}],
+            )
+
+    monkeypatch.setattr(
+        "tavily_cli.config.get_client_or_keyless",
+        lambda **kwargs: (LimitedClient(), True),
+    )
+
+    result = CliRunner().invoke(cli, ["search", "topic", "--json"])
+
+    assert result.exit_code == 3
+    assert json.loads(result.stdout) == {
+        "ok": False,
+        "error": {
+            "code": "daily_cap_reached",
+            "message": "Daily allowance reached.",
+            "stage": "request",
+            "retryable": True,
+            "window": "day",
+            "retry_after_seconds": 60,
+            "next_actions": [{"action": "login"}],
+        },
+    }
+
+
+def test_api_failure_uses_stable_error_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FailingClient:
+        def search(self, **kwargs):
+            raise RuntimeError("upstream unavailable")
+
+    monkeypatch.setattr(
+        "tavily_cli.config.get_client_or_keyless",
+        lambda **kwargs: (FailingClient(), False),
+    )
+
+    result = CliRunner().invoke(cli, ["search", "topic", "--json"])
+
+    assert result.exit_code == 4
+    assert json.loads(result.stdout) == {
+        "ok": False,
+        "error": {
+            "code": "api_error",
+            "message": "upstream unavailable",
+            "stage": "request",
+            "retryable": False,
+        },
+    }
+
+
+def test_required_auth_failure_is_machine_readable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("tavily_cli.config.get_api_key", lambda: None)
+
+    result = CliRunner().invoke(cli, ["map", "https://example.com", "--json"])
+
+    assert result.exit_code == 3
+    assert json.loads(result.stdout) == {
+        "ok": False,
+        "error": {
+            "code": "authentication_required",
+            "message": "The map command requires authentication.",
+            "stage": "auth",
+            "retryable": False,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("args", "method_name", "response", "record_type"),
+    [
+        (
+            ["search", "topic", "--jsonl"],
+            "search",
+            {"results": [{"url": "https://example.com/result"}], "response_time": 0.2},
+            "result",
+        ),
+        (
+            ["map", "https://example.com", "--jsonl"],
+            "map",
+            {"results": ["https://example.com/page"], "base_url": "https://example.com"},
+            "url",
+        ),
+        (
+            ["crawl", "https://example.com", "--jsonl"],
+            "crawl",
+            {"results": [{"url": "https://example.com/page", "raw_content": "full"}]},
+            "page",
+        ),
+    ],
+)
+def test_list_commands_offer_explicit_jsonl(
+    monkeypatch: pytest.MonkeyPatch,
+    args: list[str],
+    method_name: str,
+    response: dict,
+    record_type: str,
+) -> None:
+    class FakeClient:
+        pass
+
+    client = FakeClient()
+    setattr(client, method_name, lambda **kwargs: response)
+    monkeypatch.setattr("tavily_cli.config.require_api_key_friendly", lambda *args, **kwargs: "token")
+    monkeypatch.setattr("tavily_cli.config.get_client", lambda **kwargs: client)
+    monkeypatch.setattr("tavily_cli.config.get_client_or_keyless", lambda **kwargs: (client, False))
+
+    result = CliRunner().invoke(cli, args)
+
+    assert result.exit_code == 0, result.output
+    records = [json.loads(line) for line in result.stdout.splitlines()]
+    assert records[0]["type"] == record_type
+    assert records[-1]["type"] == "summary"
+    assert records[-1]["data"]["result_count"] == 1

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,0 +1,91 @@
+"""OAuth MCP transport compatibility."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from tavily import TavilyKeylessLimitError
+
+from tavily_cli import mcp_client
+
+
+def test_research_options_and_status_use_remote_compatibility_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, dict]] = []
+
+    def fake_call(token, tool_name, arguments, **kwargs):
+        calls.append((tool_name, arguments))
+        return {"status": "completed"}
+
+    monkeypatch.setattr(mcp_client, "_call_mcp_tool", fake_call)
+    client = mcp_client.McpTavilyClient("oauth-token")
+    schema = {"properties": {"answer": {"type": "string"}}}
+
+    client.research(input="topic", output_schema=schema, citation_format="apa")
+    client.get_research("req-123")
+
+    assert calls == [
+        (
+            "tavily_research",
+            {"input": "topic", "output_schema": schema, "citation_format": "apa"},
+        ),
+        ("tavily_get_research", {"request_id": "req-123"}),
+    ]
+
+
+def test_keyless_mcp_limit_becomes_typed_limit_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "structuredContent": {
+                "code": "daily_cap_reached",
+                "message": "Daily allowance reached.",
+                "auth_mode": "keyless",
+                "retry_after_seconds": 60,
+                "next_actions": [{"action": "login"}],
+            }
+        },
+    }
+
+    class FakeResponse:
+        text = f"data:{json.dumps(payload)}"
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(mcp_client.httpx, "post", lambda *args, **kwargs: FakeResponse())
+
+    with pytest.raises(TavilyKeylessLimitError) as exc_info:
+        mcp_client._call_mcp_tool("oauth-token", "tavily_search", {"query": "topic"})
+
+    assert exc_info.value.code == "daily_cap_reached"
+    assert exc_info.value.retry_after_seconds == 60
+
+
+def test_failed_research_response_is_returned_for_exit_handling(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "structuredContent": {
+                "request_id": "req-failed",
+                "status": "failed",
+                "error": "Research failed upstream.",
+            }
+        },
+    }
+
+    class FakeResponse:
+        text = f"data:{json.dumps(payload)}"
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(mcp_client.httpx, "post", lambda *args, **kwargs: FakeResponse())
+
+    assert mcp_client._call_mcp_tool("oauth-token", "tavily_get_research", {}) == {
+        "request_id": "req-failed",
+        "status": "failed",
+        "error": "Research failed upstream.",
+    }

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -488,7 +488,13 @@ def test_logout_json_reports_partial_revocation_failure(monkeypatch: pytest.Monk
         "local_credentials_cleared": True,
         "environment_credential_present": False,
         "server_revoked": False,
-        "error": "Token revocation failed (HTTP 500).",
+        "ok": False,
+        "error": {
+            "code": "oauth_revocation_failed",
+            "message": "Token revocation failed (HTTP 500).",
+            "stage": "auth",
+            "retryable": True,
+        },
     }
 
 
@@ -991,10 +997,13 @@ def test_search_json_reports_refresh_failure_without_keyless_fallback(monkeypatc
 
     assert result.exit_code == 3
     assert json.loads(result.stdout) == {
+        "ok": False,
         "error": {
             "code": "oauth_refresh_failed",
             "message": "network down",
-        }
+            "stage": "auth",
+            "retryable": True,
+        },
     }
 
 
@@ -1010,8 +1019,13 @@ def test_api_key_login_json_reports_replacement_revocation_failure(monkeypatch: 
 
     assert result.exit_code == 3
     assert json.loads(result.stdout) == {
-        "authenticated": False,
-        "error": "old session revocation failed",
+        "ok": False,
+        "error": {
+            "code": "authentication_failed",
+            "message": "old session revocation failed",
+            "stage": "auth",
+            "retryable": False,
+        },
     }
 
 
@@ -1046,8 +1060,13 @@ def test_oauth_login_json_reports_replacement_revocation_failure(monkeypatch: py
 
     assert result.exit_code == 3
     assert json.loads(result.stdout) == {
-        "authenticated": False,
-        "error": "old session revocation failed",
+        "ok": False,
+        "error": {
+            "code": "authentication_failed",
+            "message": "old session revocation failed",
+            "stage": "auth",
+            "retryable": False,
+        },
     }
 
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -451,7 +451,12 @@ def test_update_check_failure_is_structured(monkeypatch: pytest.MonkeyPatch) -> 
 
     assert result.exit_code == 4
     assert json.loads(result.stdout) == {
-        "error": {"message": "PyPI unavailable", "stage": "check"},
+        "error": {
+            "code": "update_check_failed",
+            "message": "PyPI unavailable",
+            "retryable": True,
+            "stage": "check",
+        },
         "ok": False,
     }
 
@@ -468,7 +473,12 @@ def test_install_detection_failure_is_not_reported_as_network_error(monkeypatch:
 
     assert result.exit_code == 1
     output = json.loads(result.stdout)
-    assert output["error"] == {"message": "Package metadata unavailable", "stage": "install_method"}
+    assert output["error"] == {
+        "code": "update_unsupported_install",
+        "message": "Package metadata unavailable",
+        "retryable": False,
+        "stage": "install_method",
+    }
 
 
 def test_update_does_nothing_when_current(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -556,7 +566,12 @@ def test_update_reports_unsafe_manager_binary_directory(monkeypatch: pytest.Monk
 
     assert result.exit_code == 1
     assert json.loads(result.stdout) == {
-        "error": {"message": reason, "stage": "install_method"},
+        "error": {
+            "code": "update_unsupported_install",
+            "message": reason,
+            "retryable": False,
+            "stage": "install_method",
+        },
         "ok": False,
     }
 
@@ -593,7 +608,15 @@ def test_update_failure_is_structured_and_sanitized(monkeypatch: pytest.MonkeyPa
 
     assert result.exit_code == 1
     output = json.loads(result.stdout)
-    assert output == {"error": {"message": "failed[2J", "stage": "update"}, "ok": False}
+    assert output == {
+        "error": {
+            "code": "update_failed",
+            "message": "failed[2J",
+            "retryable": True,
+            "stage": "update",
+        },
+        "ok": False,
+    }
 
 
 def test_update_verifies_package_manager_changed_version(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- standardize machine-readable operational failures as `{ "ok": false, "error": { "code", "message", "stage", "retryable", "request_id"? } }`
- return nonzero exits for research timeouts and failed research tasks
- add `extract --fail-on-partial` with exit code 5
- add explicit `--jsonl` output for search, extract, crawl, map, and research streams
- make `research --stream --json` return one JSON document while `--jsonl` emits individual events
- keep progress and diagnostics on stderr in machine modes
- validate research output-schema files locally and preserve MCP failed-research/keyless responses for correct CLI handling

## Why

Automation needs a predictable stdout contract and exit status. Previously, research timeouts and failed tasks could exit successfully, streaming `--json` was implicitly NDJSON, partial extraction had no opt-in failure policy, and error shapes varied by command.

## Compatibility notes

- human output remains the default
- successful `--json` response bodies retain their existing API shape
- failure JSON is intentionally standardized and is therefore a machine-contract change
- callers consuming one JSON object per streamed line must switch from `--json --stream` to `--jsonl --stream`
- exit code 5 is reserved for `--fail-on-partial`; existing extraction behavior is unchanged unless the flag is supplied

## Test plan

- `python -m pytest -q` — 138 passed
- `ruff check tavily_cli tests`
- `uv build`

## Stack

Base: `feat/artifact-output`

This PR depends on the artifact output layer for atomic JSONL writes, generated `.tavily/<command>/` paths, overwrite protection, and machine-readable artifact summaries. Merge the artifact PR first, then retarget this PR to `main`.

## OAuth research note

The corresponding remote-MCP server compatibility patch is prepared separately. It must be deployed before OAuth-authenticated `--output-schema` and research status/poll can work end to end; this CLI PR covers the client-side contract and regression handling.
